### PR TITLE
doors: door autoclose fix

### DIFF
--- a/mods/mtg/doors/mod.conf
+++ b/mods/mtg/doors/mod.conf
@@ -1,4 +1,4 @@
 name = doors
 description = Minetest Game mod: doors
-depends = default
+depends = default, ctf_settings
 optional_depends = screwdriver


### PR DESCRIPTION
I added a setting to the player inventory using ctf_settings. Since, as far as I understand, the ctf_settings.get function checks the player meta and thus the hard drive every time it's called, I created a table that stores the setting for each affected player in RAM to improve performance.