### PR TITLE
Map voting

### DIFF
--- a/mods/ctf/ctf_modebase/init.lua
+++ b/mods/ctf/ctf_modebase/init.lua
@@ -77,7 +77,8 @@ ctf_core.include_files(
 	"skip_vote.lua",
 	"recent_rankings.lua",
 	"bounty_algo.lua",
-	"features.lua"
+	"features.lua",
+	"map_vote.lua"
 )
 
 minetest.register_on_mods_loaded(function()

--- a/mods/ctf/ctf_modebase/map_catalog.lua
+++ b/mods/ctf/ctf_modebase/map_catalog.lua
@@ -44,7 +44,7 @@ minetest.register_on_mods_loaded(function()
 	assert(#ctf_modebase.map_catalog.maps > 0 or ctf_core.settings.server_mode == "mapedit")
 end)
 
-function ctf_modebase.map_catalog.select_map(filter, full_pool)
+function ctf_modebase.map_catalog.sample_maps(filter, full_pool, n)
 	local maps = {}
 	for _, pool in pairs({maps_pool, full_pool and used_maps}) do
 		for idx, map in ipairs(pool) do
@@ -54,8 +54,26 @@ function ctf_modebase.map_catalog.select_map(filter, full_pool)
 		end
 	end
 
-	local selected = maps[math.random(1, #maps)]
+	--Sample the n maps randomly
+	local function shuffle(t)
+		for i = #t, 2, -1 do
+			local j = math.random(i)
+			t[i], t[j] = t[j], t[i]
+		end
+	end
+	shuffle(maps)
 
+	local selected = {}
+	for i = 1, n do
+		table.insert(selected, maps[i])
+	end
+
+
+	return selected
+end
+
+
+function ctf_modebase.map_catalog.select_map(selected)
 	if not selected then
 		selected = ctf_modebase.map_catalog.map_dirnames["plains"]
 	end
@@ -81,8 +99,8 @@ function ctf_modebase.map_catalog.select_map(filter, full_pool)
 	end
 end
 
-function ctf_modebase.map_catalog.select_map_for_mode(mode)
-	ctf_modebase.map_catalog.select_map(function(map)
+function ctf_modebase.map_catalog.sample_map_for_mode(mode, n)
+	return ctf_modebase.map_catalog.sample_maps(function(map)
 		return not map.game_modes or table.indexof(map.game_modes, mode) ~= -1
-	end)
+	end, nil, n)
 end

--- a/mods/ctf/ctf_modebase/map_vote.lua
+++ b/mods/ctf/ctf_modebase/map_vote.lua
@@ -63,9 +63,21 @@ local function show_mapchoose_form(player)
         type = "button",
         exit = true,
         label = "Exit Game",
-        pos = {x = "center", y = 8},
+        pos = {x = (i / 2) + 0.5, y = 8},
+        size = {x = 3, y = 0.6},
         func = function(playername, fields, field_name)
             minetest.kick_player(playername, "You clicked 'Exit Game' in the map vote formspec")
+        end,
+    }
+
+    elements["abstain_button"] = {
+        type = "button",
+        exit = true,
+        label = "Abstain",
+        pos = {x = (i / 2) - 3.5, y = 8},
+        size = {x = 3, y = 0.6},
+        func = function(playername, fields, field_name)
+            player_vote(playername, nil)
         end,
     }
     
@@ -166,8 +178,10 @@ function ctf_modebase.map_vote.end_vote()
     minetest.chat_send_all("Map voting is over. The next map will be " .. winner_name)
 
     minetest.chat_send_all("Vote results:")
-    for mapID, count in pairs(vote_counts) do
+    for _, mapID in pairs(map_sample) do
         local map_name = ctf_modebase.map_catalog.map_names[mapID] or ("Unknown (" .. tostring(mapID) .. ")")
+        local count = vote_counts[mapID] or 0
+
         minetest.chat_send_all(count .." vote(s) for " .. map_name)
     end
 

--- a/mods/ctf/ctf_modebase/map_vote.lua
+++ b/mods/ctf/ctf_modebase/map_vote.lua
@@ -1,0 +1,188 @@
+local VOTING_TIME = 20
+
+local selected = nil
+local timer = nil
+local formspec_send_timer = nil
+local votes = nil
+local voted = nil
+local voters_count = nil
+
+ctf_modebase.map_vote = {}
+
+local function player_vote(name, mapID)
+	if not voted then return end
+
+    print("Player " .. name .. ' Vote' .. mapID)
+
+	if not voted[name] then
+		voters_count = voters_count - 1
+	end
+
+	voted[name] = true
+	votes[name] = mapID
+
+	if voters_count == 0 then
+		ctf_modebase.map_vote.end_vote()
+	end
+end
+
+local function show_mapchoose_form(player)
+    local elements = {}
+
+
+    -- local image_texture = "empty_map_screenshot.png"
+    -- --local image_texture = current_map_meta.dirname .. "_screenshot.png"
+	-- if ctf_core.file_exists(string.format"%s/textures/%s", minetest.get_modpath("ctf_map"), image_texture)) then
+    --     print("Exists image")
+    --     elements["map_1"] = {
+    --         type = "image",
+    --         pos = {x = 0, y = 0},
+    --         image_scale = -100,
+    --         z_index = 1001,
+    --         texture = image_texture
+    --         --texture = map.dirname.."_screenshot.png^[opacity:30",
+    --     }
+    -- end
+
+    local i = 0.4
+
+    -- Create vote buttons dynamically
+    for idx, mapID in ipairs(selected) do
+        elements["vote_button_" .. idx] = {
+            type = "button",
+            exit = true,
+            label = ctf_modebase.map_catalog.map_names[mapID],
+            pos = {x = "center", y = i},
+            func = function(playername, fields, field_name)
+                player_vote(playername, mapID)
+            end,
+        }
+        i = i + 1
+    end
+    
+    -- Add quit button
+    i = i + 1.2
+    elements["quit_button"] = {
+        type = "button",
+        exit = true,
+        label = "Exit Game",
+        pos = {x = "center", y = i},
+        func = function(playername, fields, field_name)
+            minetest.kick_player(playername, "You clicked 'Exit Game' in the map vote formspec")
+        end,
+    }
+    i = i + (ctf_gui.ELEM_SIZE.y - 0.2)
+    
+    ctf_gui.old_show_formspec(player, "ctf_modebase:map_select", {
+        size = {x = 8, y = i + 3.5},
+        title = "Vote for the next map",
+        description = "Please click on the map that you would like to play next!",
+        header_height = 1.4,
+        elements = elements,
+    })
+    
+end
+
+local function send_formspec()
+	if not voted then return end
+	for pname in pairs(voted) do
+		if not voted[pname] then
+			show_mapchoose_form(pname)
+		end
+	end
+	formspec_send_timer = minetest.after(2, send_formspec)
+end
+
+
+function ctf_modebase.map_vote.start_vote()
+    votes = {}
+    voted = {}
+    voters_count = 0
+
+    selected = ctf_modebase.map_catalog.sample_map_for_mode(ctf_modebase.current_mode, 3) --select three maps at random
+
+    for _, player in pairs(minetest.get_connected_players()) do
+		--if ctf_teams.get(player) ~= nil or not ctf_modebase.current_mode then
+		local pname = player:get_player_name()
+
+		show_mapchoose_form(pname)
+
+		voted[pname] = false
+		voters_count = voters_count + 1
+		--end
+	end
+
+    timer = minetest.after(VOTING_TIME, ctf_modebase.map_vote.end_vote)
+    formspec_send_timer = minetest.after(2, send_formspec)
+end
+
+
+function ctf_modebase.map_vote.end_vote()
+    if timer then
+		timer:cancel()
+		timer = nil
+	end
+    if formspec_send_timer then
+		formspec_send_timer:cancel()
+		formspec_send_timer = nil
+	end
+
+    for _, player in pairs(minetest.get_connected_players()) do
+		minetest.close_formspec(player:get_player_name(), "ctf_modebase:map_select")
+	end
+    
+    local vote_counts = {}
+    for _, mapID in pairs(votes) do
+        vote_counts[mapID] = (vote_counts[mapID] or 0) + 1
+    end
+
+	votes = nil
+	voted = nil
+
+    local winning_mapID = nil
+    local max_votes = 0
+    for mapID, count in pairs(vote_counts) do
+        if count > max_votes then
+            max_votes = count
+            winning_mapID = mapID
+        end
+    end
+
+    local winner_name = ctf_modebase.map_catalog.map_names[winning_mapID] or tostring(winning_mapID)
+    minetest.chat_send_all("Map voting is over. The next map will be " .. winner_name)
+
+    minetest.chat_send_all("Vote results:")
+    for mapID, count in pairs(vote_counts) do
+        local map_name = ctf_modebase.map_catalog.map_names[mapID] or ("Unknown (" .. tostring(mapID) .. ")")
+        minetest.chat_send_all(count .." vote(s) for " .. map_name)
+    end
+
+    ctf_modebase.map_catalog.select_map(winning_mapID)
+    ctf_modebase.start_match_after_map_vote()
+end
+
+minetest.register_on_joinplayer(function(player)
+	local pname = player:get_player_name()
+
+	if votes and not voted[pname] then
+		show_mapchoose_form(pname)
+		voted[pname] = false
+		voters_count = voters_count + 1
+	end
+end)
+
+minetest.register_on_leaveplayer(function(player)
+	local pname = player:get_player_name()
+
+	if votes and not voted[pname] then
+		voters_count = voters_count - 1
+
+		if voters_count == 0 then
+			ctf_modebase.map_vote.end_vote()
+		end
+	end
+
+	if voted then
+		voted[pname] = nil
+	end
+end)

--- a/mods/ctf/ctf_modebase/map_vote.lua
+++ b/mods/ctf/ctf_modebase/map_vote.lua
@@ -1,5 +1,5 @@
 local VOTING_TIME = 20
-local NUM_MAPS_VOTE = 4
+local NUM_MAPS_VOTE = 3
 
 
 local map_sample = nil
@@ -28,38 +28,49 @@ end
 
 local function show_mapchoose_form(player)
     local elements = {}
-
-    local i = 0.4
+    local i = 1
 
     -- Create vote buttons
     for idx, mapID in ipairs(map_sample) do
+
+        local image_texture = ctf_modebase.map_catalog.maps[mapID].dirname .. "_screenshot.png"
+        local image_path = string.format("%s/textures/%s", minetest.get_modpath("ctf_map"), image_texture)
+
+        if ctf_core.file_exists(image_path) then
+            elements["map_image_" .. idx] = {
+                type = "image",
+                pos = {x = i, y = 1},
+                size = {x = 6, y = 4},
+                texture = image_texture,
+            }
+        end
+
         elements["vote_button_" .. idx] = {
             type = "button",
             exit = true,
             label = ctf_modebase.map_catalog.map_names[mapID],
-            pos = {x = "center", y = i},
+            pos = {x = i + 1, y = 6},
+            size = {x = 4, y = 1},
             func = function(playername, fields, field_name)
                 player_vote(playername, mapID)
             end,
         }
-        i = i + 1
+        i = i + 7
     end
     
     -- Add quit button
-    i = i + 1.2
     elements["quit_button"] = {
         type = "button",
         exit = true,
         label = "Exit Game",
-        pos = {x = "center", y = i},
+        pos = {x = "center", y = 8},
         func = function(playername, fields, field_name)
             minetest.kick_player(playername, "You clicked 'Exit Game' in the map vote formspec")
         end,
     }
-    i = i + (ctf_gui.ELEM_SIZE.y - 0.2)
     
     ctf_gui.old_show_formspec(player, "ctf_modebase:map_select", {
-        size = {x = 8, y = i + 3.5},
+        size = {x = i, y = 11},
         title = "Vote for the next map",
         description = "Please click on the map that you would like to play next!",
         header_height = 1.4,

--- a/mods/ctf/ctf_modebase/match.lua
+++ b/mods/ctf/ctf_modebase/match.lua
@@ -9,7 +9,7 @@ ctf_modebase.mode_on_next_match = nil
 function ctf_modebase.map_chosen(map)
 end
 
-function ctf_modebase.start_match_after_vote()
+function ctf_modebase.start_match_after_mode_vote()
 	local old_mode = ctf_modebase.current_mode
 
 	if ctf_modebase.mode_on_next_match ~= old_mode then
@@ -22,10 +22,13 @@ function ctf_modebase.start_match_after_vote()
 	if ctf_modebase.map_on_next_match then
 		ctf_modebase.map_catalog.current_map = ctf_modebase.map_catalog.map_dirnames[ctf_modebase.map_on_next_match]
 		ctf_modebase.map_on_next_match = nil
+		ctf_modebase.start_match_after_map_vote()
 	else
-		ctf_modebase.map_catalog.select_map_for_mode(ctf_modebase.current_mode)
+		ctf_modebase.map_vote.start_vote()
 	end
+end
 
+function ctf_modebase.start_match_after_map_vote()
 	ctf_modebase.show_loading_screen()
 	local map = ctf_modebase.map_catalog.maps[ctf_modebase.map_catalog.current_map]
 	ctf_modebase.map_chosen(map)
@@ -71,15 +74,14 @@ local function start_new_match()
 
 	if ctf_modebase.mode_on_next_match then
 		ctf_modebase.current_mode_matches_played = 0
-		ctf_modebase.start_match_after_vote()
-	-- Show mode selection form every 'current_mode_matches'-th match
+		ctf_modebase.start_match_after_mode_vote()
 	elseif ctf_modebase.current_mode_matches_played >= ctf_modebase.current_mode_matches or
 	not ctf_modebase.current_mode then
 		ctf_modebase.current_mode_matches_played = 0
 		ctf_modebase.mode_vote.start_vote()
 	else
 		ctf_modebase.mode_on_next_match = ctf_modebase.current_mode
-		ctf_modebase.start_match_after_vote()
+		ctf_modebase.start_match_after_mode_vote()
 	end
 end
 

--- a/mods/ctf/ctf_modebase/mode_vote.lua
+++ b/mods/ctf/ctf_modebase/mode_vote.lua
@@ -219,7 +219,7 @@ function ctf_modebase.mode_vote.end_vote()
 		ctf_modebase.mode_vote.start_vote()
 	else
 		ctf_modebase.mode_on_next_match = new_mode
-		ctf_modebase.start_match_after_vote()
+		ctf_modebase.start_match_after_mode_vote()
 	end
 end
 


### PR DESCRIPTION
This pull request introduces a map voting system where players vote for the next map to be played. Four (can be changed) maps are selected from the available maps at random. After mode voting and before the map is loaded the players get to cast 1 vote by using the buttons. Map voting lasts for 20 seconds (can be changed). The map with the most votes is the one that is going to be played next. Ties are handled by selecting randomly. 

![image](https://github.com/user-attachments/assets/6fe87fa2-9d2f-4c48-9af1-c8d2b4c6238b)
