### PR TITLE
Reduce score when capturing the flag

### DIFF
--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -804,7 +804,7 @@ return {
 
 		celebrate_team(ctf_teams.get(pname))
 
-		recent_rankings.add(pname, {score = 30, flag_attempts = 1})
+		recent_rankings.add(pname, {score = 15, flag_attempts = 1})
 
 		ctf_modebase.flag_huds.track_capturer(pname, FLAG_CAPTURE_TIMER)
 	end,


### PR DESCRIPTION
I made this pull request to counter players who just farm the score thanks to this, ruining the games of many players by always trying to capture as quickly as possible. Some players in the top 10 are in it just because of this, they have a very low kd. So I think that by reducing the score during the capture, (30 --> 15), these players will try to pvp to get the flag rather than taking the flag for the score and leaving. (Knowing that the longer a game lasts, the more the flag can bring in by capturing it).