### PR TITLE
Allow maps to register custom globalstep functions

### DIFF
--- a/mods/ctf/ctf_map/init.lua
+++ b/mods/ctf/ctf_map/init.lua
@@ -34,6 +34,8 @@ ctf_map = {
 	-- Table of map paths. Indexed by map's folder name
 	-- Doesn't include trailing '/'
 	map_path = {},
+
+	globalstep_function = nil,
 }
 
 function ctf_map.register_map(dirname, path_to_map)
@@ -120,7 +122,8 @@ ctf_core.include_files(
 	"map_functions.lua",
 	"editor_functions.lua",
 	"mapedit_gui.lua",
-	"ctf_traps.lua"
+	"ctf_traps.lua",
+	"map_api.lua"
 )
 
 local directory = minetest.get_modpath(minetest.get_current_modname()) .. "/maps/"

--- a/mods/ctf/ctf_map/map_api.lua
+++ b/mods/ctf/ctf_map/map_api.lua
@@ -1,0 +1,22 @@
+minetest.register_globalstep(function(dtime)
+	if ctf_map.globalstep_function then
+		pcall(ctf_map.globalstep_function, dtime)
+	end
+end)
+
+function ctf_map.set_globalstep_function(globalstep_function)
+    if globalstep_function == nil then
+        ctf_map.globalstep_function = nil
+    elseif type(globalstep_function) == "function" then
+        ctf_map.globalstep_function = globalstep_function
+    else
+        error("globalstep_function must be a function or nil, got " .. type(globalstep_function))
+    end
+end
+
+
+ctf_api.register_on_match_end(function()
+	minetest.after(0, function()
+		ctf_map.globalstep_function = nil
+	end)
+end)


### PR DESCRIPTION
This API allows only one map's globalstep to run. After the match ends, it uses the next map's globalstep.