### PR TITLE
Item return score rework

### DIFF
--- a/mods/ctf/ctf_modebase/features.lua
+++ b/mods/ctf/ctf_modebase/features.lua
@@ -1,3 +1,40 @@
+--- @alias Vec3 { x: number, y: number, z: number }
+
+--- @type { [string]: number }
+local default_item_value = {
+	["ctf_melee:sword_diamond"] = 12,
+	["ctf_ranged:shotgun_loaded"] = 12,
+	["ctf_melee:sword_mese"] = 11,
+	["ctf_ranged:shotgun"] = 10,
+	["ctf_ranged:sniper_magnum_loaded"] = 12,
+	["default:axe_diamond"] = 8,
+	["ctf_ranged:sniper_magnum"] = 10,
+	["ctf_ranged:assault_rifle_loaded"] = 8,
+	["rocket_launcher:launcher"] = 8,
+	["default:sword_steel"] = 7,
+	["ctf_melee:sword_steel"] = 7,
+	["default:pick_diamond"] = 6,
+	["ctf_ranged:assault_rifle"] = 6,
+	["grenades:frag"] = 6,
+	["ctf_healing:medkit"] = 6,
+	["default:pick_mese"] = 5,
+	["default:axe_mese"] = 5,
+	["grenades:poison"] = 5,
+	["ctf_ranged:rifle_loaded"] = 5,
+	["ctf_ranged:smg_loaded"] = 5,
+	["ctf_ranged:rifle"] = 4,
+	["ctf_ranged:smg"] = 4,
+	["ctf_healing:bandage"] = 4,
+	["default:shovel_diamond"] = 4,
+	["grenades:smoke"] = 2,
+	["ctf_ranged:pistol_loaded"] = 2,
+	["default:shovel_steel"] = 2,
+	["default:pick_steel"] = 1,
+	["default:axe_steel"] = 1,
+	["default:shovel_mese"] = 1,
+	["ctf_ranged:pistol"] = 1,
+}
+
 ctf_core.testing = {
 	-- This is here temporarily, I'm modifying it with //lua and a code minimizer on the main server-
 	-- -so I don't need to restart for every little change
@@ -5,18 +42,32 @@ ctf_core.testing = {
 	--ctf_core.testing.
 	testing = true,
 	test = function(
-		pkd, kd_diff, actual_kd_diff, players_diff, best_kd, worst_kd, total_players, worst_players, best_players
+		pkd,
+		kd_diff,
+		actual_kd_diff,
+		players_diff,
+		best_kd,
+		worst_kd,
+		total_players,
+		worst_players,
+		best_players
 	)
-		local one_third     = math.ceil(0.34 * total_players)
-		local one_fourth     = math.ceil(0.25 * total_players)
+		local one_third = math.ceil(0.34 * total_players)
+		local one_fourth = math.ceil(0.25 * total_players)
 		local avg = (kd_diff + actual_kd_diff) / 2
 		if best_kd.kills + worst_kd.kills >= 30 then
 			avg = actual_kd_diff
 		end
-		return (best_kd.kills + worst_kd.kills >= 30 and best_kd.t == best_players.t) or
-		(pkd >= math.min(1, kd_diff/2) and avg >= 0.4 and (players_diff <= one_fourth or
-		(pkd >= 1.5 and players_diff <= one_third)))
-	end
+		return (best_kd.kills + worst_kd.kills >= 30 and best_kd.t == best_players.t)
+			or (
+				pkd >= math.min(1, kd_diff / 2)
+				and avg >= 0.4
+				and (
+					players_diff <= one_fourth
+					or (pkd >= 1.5 and players_diff <= one_third)
+				)
+			)
+	end,
 }
 
 local hud = mhud.init()
@@ -33,10 +84,10 @@ function ctf_modebase.map_chosen(map, ...)
 
 			hud:add(p, "map_image", {
 				type = "image",
-				position = {x = 0.5, y = 0.5},
+				position = { x = 0.5, y = 0.5 },
 				image_scale = -100,
 				z_index = 1001,
-				texture = map.dirname.."_screenshot.png^[opacity:30",
+				texture = map.dirname .. "_screenshot.png^[opacity:30",
 			})
 
 			hud:change(p, "loading_text", {
@@ -55,7 +106,9 @@ end
 
 local function supports_observers(x)
 	if x then
-		if x.object then x = x.object end
+		if x.object then
+			x = x.object
+		end
 		if x.get_observers and x:get_pos() then
 			return true
 		end
@@ -64,9 +117,10 @@ local function supports_observers(x)
 end
 
 local function update_playertag(player, t, nametag, team_nametag, symbol_nametag)
-	if not      supports_observers(nametag.object) or
-	   not supports_observers(team_nametag.object) or
-	   not supports_observers(symbol_nametag.object)
+	if
+		not supports_observers(nametag.object)
+		or not supports_observers(team_nametag.object)
+		or not supports_observers(symbol_nametag.object)
 	then
 		return
 	end
@@ -77,7 +131,10 @@ local function update_playertag(player, t, nametag, team_nametag, symbol_nametag
 	nametag_players[player:get_player_name()] = nil
 
 	for n in pairs(table.copy(nametag_players)) do
-		local setting = ctf_settings.get(minetest.get_player_by_name(n), "ctf_modebase:teammate_nametag_style")
+		local setting = ctf_settings.get(
+			minetest.get_player_by_name(n),
+			"ctf_modebase:teammate_nametag_style"
+		)
 
 		if setting == "3" then
 			nametag_players[n] = nil
@@ -142,7 +199,11 @@ local function set_playertags_state(state)
 				local nametag = playertag.entity
 				local symbol_entity = playertag.symbol_entity
 
-				if supports_observers(nametag) and supports_observers(team_nametag) and supports_observers(symbol_entity) then
+				if
+					supports_observers(nametag)
+					and supports_observers(team_nametag)
+					and supports_observers(symbol_entity)
+				then
 					team_nametag.object:set_observers({})
 					symbol_entity.object:set_observers({})
 					nametag.object:set_observers({})
@@ -152,26 +213,24 @@ local function set_playertags_state(state)
 	end
 end
 
-
-
 function ctf_modebase.show_loading_screen()
 	set_playertags_state(PLAYERTAGS_OFF)
 	for _, p in pairs(minetest.get_connected_players()) do
 		if ctf_teams.get(p) then
 			hud:add(p, "loading_screen", {
 				type = "image",
-				position = {x = 0.5, y = 0.5},
+				position = { x = 0.5, y = 0.5 },
 				image_scale = -100.5,
 				z_index = 1000,
-				texture = "[combine:1x1^[invert:rgba^[opacity:1^[colorize:#34323d:255"
+				texture = "[combine:1x1^[invert:rgba^[opacity:1^[colorize:#34323d:255",
 			})
 
 			-- z_index 1001 is reserved for the next map's image. Search file for `tag: map_image`
 
 			hud:add(p, "loading_text", {
 				type = "text",
-				position = {x = 0.5, y = 0.5},
-				alignment = {x = "center", y = "up"},
+				position = { x = 0.5, y = 0.5 },
+				alignment = { x = "center", y = "up" },
 				text_scale = 2,
 				text = "Loading Next Map...",
 				color = 0x7ec5ff,
@@ -179,8 +238,8 @@ function ctf_modebase.show_loading_screen()
 			})
 			hud:add(p, {
 				type = "text",
-				position = {x = 0.5, y = 0.75},
-				alignment = {x = "center", y = "center"},
+				position = { x = 0.5, y = 0.75 },
+				alignment = { x = "center", y = "center" },
 				text = random_messages.get_random_message(),
 				color = 0xffffff,
 				z_index = 1002,
@@ -191,32 +250,44 @@ function ctf_modebase.show_loading_screen()
 	loading_screen_time = minetest.get_us_time()
 end
 
-
 local function is_pro(player, rank)
-	local pro_chest = player and player:get_meta():get_int("ctf_rankings:pro_chest:"..
-			(ctf_modebase.current_mode or "")) == 1
+	local pro_chest = player
+		and player
+				:get_meta()
+				:get_int("ctf_rankings:pro_chest:" .. (ctf_modebase.current_mode or ""))
+			== 1
 
 	-- Remember to update /make_pro in ranking_commands.lua if you change anything here
 	if pro_chest or rank then
 		if
 			pro_chest
-			or
-			(rank.score or 0) >= 8000 and
-			(rank.kills or 0) / (rank.deaths or 1) >= 1.4 and
-			(rank.flag_captures or 0) >= 5
+			or (rank.score or 0) >= 8000
+				and (rank.kills or 0) / (rank.deaths or 1) >= 1.4
+				and (rank.flag_captures or 0) >= 5
 		then
 			return true
 		end
 	end
 end
 
-local function flag_event_notify(pname, pteam, flags_taken, to_player_msg, to_teammates_msg, to_victims_msg, to_others_msg)
+local function flag_event_notify(
+	pname,
+	pteam,
+	flags_taken,
+	to_player_msg,
+	to_teammates_msg,
+	to_victims_msg,
+	to_others_msg
+)
 	if flags_taken and type(flags_taken) == "string" then
-		flags_taken = {flags_taken}
+		flags_taken = { flags_taken }
 	end
 
 	local function send_notify(target, def)
-		if ctf_settings.get(PlayerObj(target), "ctf_modebase:flag_notifications") == "true" then
+		if
+			ctf_settings.get(PlayerObj(target), "ctf_modebase:flag_notifications")
+			== "true"
+		then
 			hud_events.new(target, def)
 		end
 	end
@@ -266,842 +337,986 @@ ctf_settings.register("ctf_modebase:flag_notifications", {
 ctf_settings.register("ctf_modebase:teammate_nametag_style", {
 	type = "list",
 	description = "Controls what style of nametag to use for teammates.",
-	list = {"Minetest Nametag: Full", "Minetest Nametag: Symbol", "Entity Nametag"},
+	list = { "Minetest Nametag: Full", "Minetest Nametag: Symbol", "Entity Nametag" },
 	default = "1",
 	on_change = function(player, new_value)
-		minetest.log("action", "Player "..player:get_player_name().." changed their nametag setting")
+		minetest.log(
+			"action",
+			"Player " .. player:get_player_name() .. " changed their nametag setting"
+		)
 		update_playertags()
-	end
+	end,
 })
 
 ctf_modebase.features = function(rankings, recent_rankings)
+	local FLAG_MESSAGE_COLOR = "#d9b72a"
+	local FLAG_CAPTURE_TIMER = 60 * 3
+	local many_teams = false
+	local team_list
+	local teams_left
 
-local FLAG_MESSAGE_COLOR = "#d9b72a"
-local FLAG_CAPTURE_TIMER = 60 * 3
-local many_teams = false
-local team_list
-local teams_left
-
-local function calculate_killscore(player)
-	local match_rank = recent_rankings.players()[player] or {}
-	local kd = (match_rank.kills or 1) / (match_rank.deaths or 1)
-	local flag_multiplier = 1
-	for tname, carrier in pairs(ctf_modebase.flag_taken) do
-		if carrier.p == player then
-			flag_multiplier = flag_multiplier + 0.25
-		end
-	end
-	return math.max(1, math.round(kd * 7 * flag_multiplier))
-end
-
-local damage_group_textures = {
-	grenade = "grenades_frag.png",
-	knockback_grenade = "ctf_mode_nade_fight_knockback_grenade.png",
-	black_hole_grenade = "ctf_mode_nade_fight_black_hole_grenade.png",
-	damage_cobble = "ctf_map_damage_cobble.png",
-	landmine = "ctf_landmine_landmine.png",
-	spike = "ctf_map_spike.png",
-}
-
-local function get_weapon_image(hitter, tool_capabilities)
-	local image
-
-	for group, texture in pairs(damage_group_textures) do
-		if tool_capabilities.damage_groups[group] then
-			image = texture
-			break
-		end
-	end
-
-	if not image then
-		image = hitter:get_wielded_item():get_definition().inventory_image
-	end
-
-	if image == "" then
-		image = "ctf_kill_list_punch.png"
-	end
-
-	if tool_capabilities.damage_groups.ranged then
-		image = image .. "^[transformFX"
-	elseif tool_capabilities.damage_groups.poison_grenade then
-		image = "grenades_smoke_grenade.png^[multiply:#00ff00"
-	end
-
-	return image
-end
-
-local function get_suicide_image(reason)
-	local image = "ctf_modebase_skull.png"
-
-	if reason.type == "node_damage" then
-		local node = reason.node
-		if node:find("lava") then
-			return "default_lava.png"
-		end
-
-		local node_def = minetest.registered_nodes[node]
-		if node_def then
-			local inv_image = node_def.inventory_image
-			if inv_image and inv_image ~= "" then
-				image = inv_image
-			elseif node_def.tiles and node_def.tiles[1] then
-				local tiles1 = node_def.tiles[1]
-				if type(tiles1) == "string" then
-					image = tiles1
-				elseif tiles1.name and tiles1.name ~= "" then
-					if tiles1.animation then
-						local h = tiles1.animation.aspect_h or 16
-						return tiles1.name .. "^[verticalframe:" .. h .. ":1"
-					end
-					image = tiles1.name
-				end
+	local function calculate_killscore(player)
+		local match_rank = recent_rankings.players()[player] or {}
+		local kd = (match_rank.kills or 1) / (match_rank.deaths or 1)
+		local flag_multiplier = 1
+		for tname, carrier in pairs(ctf_modebase.flag_taken) do
+			if carrier.p == player then
+				flag_multiplier = flag_multiplier + 0.25
 			end
 		end
-	elseif reason.type == "drown" then
-		image = "bubble.png"
-	elseif reason.type == "fall" then
-		image = "ctf_kill_list_falling_man.png"
+		return math.max(1, math.round(kd * 7 * flag_multiplier))
 	end
 
-	return image
-end
+	local damage_group_textures = {
+		grenade = "grenades_frag.png",
+		knockback_grenade = "ctf_mode_nade_fight_knockback_grenade.png",
+		black_hole_grenade = "ctf_mode_nade_fight_black_hole_grenade.png",
+		damage_cobble = "ctf_map_damage_cobble.png",
+		landmine = "ctf_landmine_landmine.png",
+		spike = "ctf_map_spike.png",
+	}
 
-local function tp_player_near_flag(player)
-    local tname = ctf_teams.get(player)
-    if not tname then return end
+	local function get_weapon_image(hitter, tool_capabilities)
+		local image
 
-    local flag_pos = ctf_map.current_map.teams[tname].flag_pos
-
-    -- Generate random offset
-    local random_off = {
-        x = math.random(-1, 1),
-		y = 0,
-        z = math.random(-1, 1),
-    }
-
-    -- Avoid zero offset
-    if random_off.x == 0 and random_off.z == 0 then
-        random_off.x = 1 -- Shift along X if both are zero
-    end
-
-    local pos = vector.add(flag_pos, random_off)
-
-    local rotation_y = vector.dir_to_rotation(
-        vector.direction(pos, ctf_map.current_map.teams[tname].look_pos or ctf_map.current_map.flag_center)
-    ).y
-
-    local function apply()
-        player:set_pos(pos)
-        player:set_look_vertical(0)
-        player:set_look_horizontal(rotation_y)
-    end
-
-    apply()
-    minetest.after(0.1, function() -- TODO: remove after respawn bug is fixed
-        if player:is_player() then
-            apply()
-        end
-    end)
-
-    return true
-end
-
-local function celebrate_team(teamname)
-	for _, player in ipairs(minetest.get_connected_players()) do
-		local pname = player:get_player_name()
-		local pteam = ctf_teams.get(pname)
-
-		local sound_volume = (tonumber(ctf_settings.get(player, "ctf_modebase:flag_sound_volume")) or 10.0) / 10
-
-		if pteam == teamname then
-			minetest.sound_play("ctf_modebase_trumpet_positive", {
-				to_player = pname,
-				gain = sound_volume,
-				pitch = 1.0,
-			}, true)
-		else
-			minetest.sound_play("ctf_modebase_trumpet_negative", {
-				to_player = pname,
-				gain = sound_volume,
-				pitch = 1.0,
-			}, true)
-		end
-	end
-end
-
-local function drop_flag(teamname)
-	for _, player in ipairs(minetest.get_connected_players()) do
-		local pname = player:get_player_name()
-		local pteam = ctf_teams.get(pname)
-
-		if pteam then
-			if pteam == teamname then
-				minetest.sound_play("ctf_modebase_drop_flag_negative", {
-					to_player = pname,
-					gain = 0.2,
-					pitch = 1.0,
-				}, true)
-			else
-				minetest.sound_play("ctf_modebase_drop_flag_positive", {
-					to_player = pname,
-					gain = 0.2,
-					pitch = 1.0,
-				}, true)
-			end
-		end
-	end
-end
-
-local function end_combat_mode(player, reason, killer, weapon_image)
-	local comment = nil
-
-	if reason == "combatlog" then
-		killer, weapon_image = ctf_combat_mode.get_last_hitter(player)
-		if killer then
-			comment = " (Combat Log)"
-			recent_rankings.add(player, {deaths = 1}, true)
-		end
-	else
-		if reason ~= "punch" or killer == player then
-			if ctf_teams.get(player) then
-				if reason == "punch" then
-					ctf_kill_list.add(player, player, weapon_image)
-				else
-					ctf_kill_list.add("", player, get_suicide_image(reason))
-				end
-			end
-
-			killer, weapon_image = ctf_combat_mode.get_last_hitter(player)
-			comment = " (Suicide)"
-		end
-		recent_rankings.add(player, {deaths = 1}, true)
-	end
-
-	if killer then
-		local killscore = calculate_killscore(player)
-
-		local rewards = {kills = 1, score = killscore}
-		local bounty = ctf_modebase.bounties.claim(player, killer)
-
-		if bounty then
-			for name, amount in pairs(bounty) do
-				rewards[name] = (rewards[name] or 0) + amount
+		for group, texture in pairs(damage_group_textures) do
+			if tool_capabilities.damage_groups[group] then
+				image = texture
+				break
 			end
 		end
 
-		recent_rankings.add(killer, rewards)
-
-		if ctf_teams.get(killer) then
-			ctf_kill_list.add(killer, player, weapon_image, comment)
+		if not image then
+			image = hitter:get_wielded_item():get_definition().inventory_image
 		end
 
-		-- share kill score with other hitters
-		local hitters = ctf_combat_mode.get_other_hitters(player, killer)
-		for _, pname in ipairs(hitters) do
-			recent_rankings.add(pname, {kill_assists = 1, score = math.ceil(killscore / #hitters)})
+		if image == "" then
+			image = "ctf_kill_list_punch.png"
 		end
 
-		-- share kill score with healers
-		local healers = ctf_combat_mode.get_healers(killer)
-		for _, pname in ipairs(healers) do
-			recent_rankings.add(pname, {score = math.ceil(killscore / #healers)})
+		if tool_capabilities.damage_groups.ranged then
+			image = image .. "^[transformFX"
+		elseif tool_capabilities.damage_groups.poison_grenade then
+			image = "grenades_smoke_grenade.png^[multiply:#00ff00"
 		end
 
-		if ctf_combat_mode.is_only_hitter(killer, player) then
-			ctf_combat_mode.set_kill_time(killer, 5)
-		end
+		return image
 	end
 
-	ctf_combat_mode.end_combat(player)
-end
+	local function get_suicide_image(reason)
+		local image = "ctf_modebase_skull.png"
 
-local function can_punchplayer(player, hitter)
-	if not ctf_modebase.match_started then
-		return false, "The match hasn't started yet!"
-	end
-
-	local pname, hname = player:get_player_name(), hitter:get_player_name()
-	local pteam, hteam = ctf_teams.get(player), ctf_teams.get(hitter)
-
-	if not ctf_modebase.remove_respawn_immunity(hitter) then
-		return false, "You can't attack while immune"
-	end
-
-	if not pteam then
-		return false, pname .. " is not in a team!"
-	end
-
-	if not hteam then
-		return false, "You are not in a team!"
-	end
-
-	if pteam == hteam and pname ~= hname then
-		return false, pname .. " is on your team!"
-	end
-
-	return true
-end
-
-local item_levels = {
-	"wood",
-	"stone",
-	"bronze",
-	"steel",
-	"mese",
-	"diamond",
-}
-
-local delete_queue = {}
-local team_switch_after_capture = false
-local streak_bonus_received = {}
-
-return {
-	on_new_match = function()
-		team_list = {}
-		for tname in pairs(ctf_map.current_map.teams) do
-			table.insert(team_list, tname)
-		end
-		teams_left = #team_list
-		many_teams = #team_list > 2
-
-		-- Detach all players
-		for _, player in ipairs(core.get_connected_players()) do
-			if player:get_attach() then
-				player:set_detach()
-				core.log("action", player:get_player_name() .. " detached")
+		if reason.type == "node_damage" then
+			local node = reason.node
+			if node:find("lava") then
+				return "default_lava.png"
 			end
-		end
 
-		if #delete_queue > 0 and delete_queue._map ~= ctf_map.current_map.dirname then
-			local p1, p2 = unpack(delete_queue)
-
-			local ignore_objects = {
-				"hpbar:entity",
-				"wield3d:entity",
-				"playertag:tag",
-				"server_cosmetics:hat"
-			}
-
-			for _, obj in pairs(minetest.get_objects_in_area(p1, p2)) do
-				if not obj:is_player() then
-					local luaent = obj:get_luaentity()
-
-					if luaent and table.indexof(ignore_objects, luaent.name) == -1 then
-						obj:remove()
+			local node_def = minetest.registered_nodes[node]
+			if node_def then
+				local inv_image = node_def.inventory_image
+				if inv_image and inv_image ~= "" then
+					image = inv_image
+				elseif node_def.tiles and node_def.tiles[1] then
+					local tiles1 = node_def.tiles[1]
+					if type(tiles1) == "string" then
+						image = tiles1
+					elseif tiles1.name and tiles1.name ~= "" then
+						if tiles1.animation then
+							local h = tiles1.animation.aspect_h or 16
+							return tiles1.name .. "^[verticalframe:" .. h .. ":1"
+						end
+						image = tiles1.name
 					end
 				end
 			end
-
-			minetest.delete_area(p1, p2)
-
-			delete_queue = {}
+		elseif reason.type == "drown" then
+			image = "bubble.png"
+		elseif reason.type == "fall" then
+			image = "ctf_kill_list_falling_man.png"
 		end
 
-		-- Place treasures
-		local tr = ctf_modebase:get_current_mode().treasures or {}
-
-		local treasurefy_func
-		local no_treasures = true
-		-- If the treasures list is empty, chests will not be placed
-		if next(tr) then
-			local map_treasures = table.copy(tr)
-
-			for k, v in pairs(ctf_map.treasure.treasure_from_string(ctf_map.current_map.treasures)) do
-				map_treasures[k] = v
-			end
-			treasurefy_func = function(inv) ctf_map.treasure.treasurefy_node(inv, map_treasures) end
-			no_treasures = false
-		end
-
-
-		ctf_map.prepare_map_nodes(
-			ctf_map.current_map,
-			treasurefy_func,
-			no_treasures,
-			ctf_modebase:get_current_mode().team_chest_items or {},
-			ctf_modebase:get_current_mode().blacklisted_nodes or {}
-		)
-
-		if loading_screen_time then
-			local total_time = (minetest.get_us_time() - loading_screen_time) / 1e6
-
-			minetest.after(math.abs(LOADING_SCREEN_TARGET_TIME - total_time), function()
-				hud:clear_all()
-				set_playertags_state(PLAYERTAGS_ON)
-
-				for _, player in ipairs(minetest.get_connected_players()) do
-					minetest.close_formspec(player:get_player_name(), "ctf_modebase:summary")
-				end
-			end)
-		end
-
-	end,
-	on_match_end = function()
-		recent_rankings.on_match_end()
-
-		if ctf_map.current_map then
-			-- Queue deletion for after the players have left
-			delete_queue = {ctf_map.current_map.pos1, ctf_map.current_map.pos2, _map = ctf_map.current_map.dirname}
-		end
-		streak_bonus_received = {}
-	end,
-	team_allocator = function(player)
-		player = PlayerName(player)
-
-		local team_scores = recent_rankings.teams()
-
-		local best_kd = nil
-		local worst_kd = nil
-		local best_players = nil
-		local worst_players = nil
-		local total_players = 0
-
-		for _, team in ipairs(team_list) do
-			local players_count = ctf_teams.online_players[team].count
-			local players = ctf_teams.online_players[team].players
-
-			local bk = 0
-			local bd = 1
-
-			for name in pairs(players) do
-				local rank = rankings:get(name)
-
-				if rank then
-					if bk <= (rank.kills or 0) then
-						bk = rank.kills or 0
-						bd = rank.deaths or 0
-					end
-				end
-			end
-
-			total_players = total_players + players_count
-
-			local kd = bk / bd
-			local match_kd = 0
-			local tk = 0
-			if team_scores[team] then
-				if (team_scores[team].score or 0) >= 50 then
-					tk = team_scores[team].kills or 0
-
-					kd = math.max(kd, (team_scores[team].kills or bk) / (team_scores[team].deaths or bd))
-				end
-
-				match_kd = (team_scores[team].kills or 0) / (team_scores[team].deaths or 1)
-			end
-
-			if not best_kd or match_kd > best_kd.a then
-				best_kd = {s = kd, a = match_kd, t = team, kills = tk}
-			end
-
-			if not worst_kd or match_kd < worst_kd.a then
-				worst_kd = {s = kd, a = match_kd, t = team, kills = tk}
-			end
-
-			if not best_players or players_count > best_players.s then
-				best_players = {s = players_count, t = team}
-			end
-
-			if not worst_players or players_count < worst_players.s then
-				worst_players = {s = players_count, t = team}
-			end
-		end
-
-		if worst_players.s == 0 then
-			return worst_players.t
-		end
-
-		local kd_diff = best_kd.s - worst_kd.s
-		local actual_kd_diff = best_kd.a - worst_kd.a
-		local players_diff = best_players.s - worst_players.s
-
-		local rem_team = ctf_teams.get(player)
-		local player_rankings = recent_rankings.get(player) --[pteam.."_score"]
-
-		if ctf_core.testing.testing then
-			if not rem_team or
-			math.max(player_rankings[rem_team.."_kills"] or 0, player_rankings[rem_team.."_deaths"] or 0) <= 6 then
-				player_rankings = rankings:get(player) or {}
-			else
-				player_rankings.kills  = player_rankings[rem_team.."_kills"]  or 0
-				player_rankings.deaths = player_rankings[rem_team.."_deaths"] or 1
-			end
-		else
-			player_rankings = {}
-		end
-
-		local one_third     = math.ceil(0.34 * total_players)
-		-- local one_fifth     = math.ceil(0.2 * total_players)
-
-		-- Allocate player to remembered team unless teams are imbalanced
-		if rem_team and not ctf_modebase.flag_captured[rem_team] and
-		(worst_kd.kills <= total_players or actual_kd_diff <= 0.8) and players_diff <= one_third then
-			return rem_team
-		end
-
-		local pkd = (player_rankings.kills or 0) / (player_rankings.deaths or 1)
-		local success, result = pcall(ctf_core.testing.test,
-			pkd, kd_diff, actual_kd_diff, players_diff, best_kd, worst_kd, total_players, worst_players, best_players
-		)
-
-		if not success then
-			minetest.log("error", result)
-			result = false
-		end
-
-		-- [1]
-		-- Allocate player to the worst team if it's losing by more than 0.4KD, as long as the amount of-
-		-- players on the winning team isn't outnumbered by more than 1/5 the total players playing
-		-- TODO: extra logic
-
-		-- [2]
-		-- Otherwise allocates the player to the team with the least amount of players,
-		-- or the worst team if all teams have an equal amount of players
-		if
-		players_diff == 0
-		or
-		result
-		then
-			return worst_kd.t
-		else
-			return worst_players.t
-		end
-	end,
-	can_take_flag = function(player, teamname)
-		if not ctf_modebase.match_started then
-			tp_player_near_flag(player)
-
-			return "You can't take the enemy flag during build time!"
-		end
-	end,
-	on_flag_take = function(player, teamname)
-		local pname = player:get_player_name()
-		local pteam = ctf_teams.get(player)
-		local tcolor = ctf_teams.team[pteam].color
-
-		ctf_modebase.remove_immunity(player)
-		playertag.set(player, playertag.TYPE_BUILTIN, tcolor)
-
-		local text = " has taken the flag"
-		local flag_or_flags = " flag!"
-		local teamnames_readable = HumanReadable(teamname)
-		if many_teams then
-			text = " has taken " .. teamnames_readable .. "'s flag"
-			flag_or_flags = " flags!"
-		end
-
-		flag_event_notify(pname, pteam, teamname,
-			{text = "You have taken the " .. teamnames_readable .. flag_or_flags},
-			{text = "Your teammate " .. pname .. " has taken the " .. teamnames_readable .. flag_or_flags},
-			{text = pname .. " has taken your flag!", color = "warning"},
-			{text = pname .. text, color = "light"}
-		)
-
-		minetest.chat_send_all(
-			minetest.colorize(tcolor, pname) ..
-			minetest.colorize(FLAG_MESSAGE_COLOR, text)
-		)
-		ctf_modebase.announce(string.format("Player %s (team %s)%s", pname, pteam, text))
-
-		celebrate_team(ctf_teams.get(pname))
-
-		recent_rankings.add(pname, {score = 30, flag_attempts = 1})
-
-		ctf_modebase.flag_huds.track_capturer(pname, FLAG_CAPTURE_TIMER)
-	end,
-	on_flag_drop = function(player, teamnames, pteam)
-		local pname = player:get_player_name()
-		local tcolor = pteam and ctf_teams.team[pteam].color or "#FFF"
-
-		local text = " has dropped the flag"
-		local teamnames_notify = "Your teammate " .. pname .. text
-		if many_teams then
-			text = " has dropped the flag of team(s) " .. HumanReadable(teamnames)
-			teamnames_notify = "Your teammate " .. pname .. text
-		end
-
-		flag_event_notify(pname, pteam, teamnames,
-			nil,
-			{text = teamnames_notify, color = "light"},
-			{text = pname .. " has dropped your flag!", color = "success"},
-			{text = pname .. text, color = "light"}
-		)
-
-		minetest.chat_send_all(
-			minetest.colorize(tcolor, pname) ..
-			minetest.colorize(FLAG_MESSAGE_COLOR, text)
-		)
-		ctf_modebase.announce(string.format("Player %s (team %s)%s", pname, pteam, text))
-
-		ctf_modebase.flag_huds.untrack_capturer(pname)
-
-		playertag.set(player, playertag.TYPE_ENTITY)
-
-		if player.set_observers then
-			update_playertags()
-		end
-
-		drop_flag(pteam)
-	end,
-	on_flag_capture = function(player, teamnames)
-		local pname = player:get_player_name()
-		local pteam = ctf_teams.get(pname)
-		local tcolor = ctf_teams.team[pteam].color
-
-		playertag.set(player, playertag.TYPE_ENTITY)
-
-		if player.set_observers then
-			update_playertags()
-		end
-
-		celebrate_team(pteam)
-
-		ctf_modebase.flag_huds.untrack_capturer(pname)
-
-		local team_scores = recent_rankings.teams()
-		local capture_reward = 0
-		for _, lost_team in ipairs(teamnames) do
-			local score = ((team_scores[lost_team] or {}).score or 0) / 4
-			score = math.max(10, math.min(900, score))
-			capture_reward = capture_reward + score
-		end
-
-		local text = string.format(" has captured the flag in " .. ctf_map.get_duration() .. " and got %d points", capture_reward)
-		local teamnames_readable = HumanReadable(teamnames)
-		local flag_or_flags = " flag!"
-		if many_teams then
-			text = string.format(" has captured the flag of team(s) %s in " .. ctf_map.get_duration() .. " and got %d points",
-				teamnames_readable, capture_reward)
-			flag_or_flags = " flags!"
-		end
-
-		flag_event_notify(pname, pteam, teamnames,
-			{text = "You have captured: " .. teamnames_readable .. flag_or_flags, color = "success"},
-			{text = "Your teammate " .. pname .. " has captured: " .. teamnames_readable .. flag_or_flags, color = "success"},
-			{text = pname .. " has captured your flag!", color = "warning"},
-			{text = pname .. " has captured: " .. teamnames_readable .. flag_or_flags, color = "light"}
-		)
-
-		minetest.chat_send_all(minetest.colorize(tcolor, pname) .. minetest.colorize(FLAG_MESSAGE_COLOR, text))
-
-		ctf_modebase.announce(string.format("Player %s (team %s)%s", pname, pteam, text))
-
-		local team_score = team_scores[pteam].score
-		for teammate in pairs(ctf_teams.online_players[pteam].players) do
-			if teammate ~= pname then
-				local teammate_value = (recent_rankings.get(teammate)[pteam.."_score"] or 0) / (team_score or 1)
-				local victory_bonus = math.max(5, math.min(capture_reward / 2, capture_reward * teammate_value))
-				recent_rankings.add(teammate, {score = victory_bonus}, true)
-			end
-		end
-
-		recent_rankings.add(pname, {score = capture_reward, flag_captures = #teamnames})
-
-		local streak_idx = ctf_modebase.player_on_flag_attempt_streak[pname]
-		if streak_idx then
-			local streak_bonus = 0
-			if streak_bonus_received[pname] then
-				streak_bonus = math.floor(math.abs(streak_bonus_received[pname] - streak_idx * 20))
-			else
-				streak_bonus = math.floor(streak_idx * 20)
-			end
-			streak_bonus_received[pname] = streak_bonus
-
-			hud_events.new(pname, {
-				text = "Streak Bonus +" .. streak_bonus,
-				color = "info",
-				quick = true,
-			})
-
-			recent_rankings.add(pname, {score =  streak_bonus}, true)
-		end
-
-		teams_left = teams_left - #teamnames
-
-		if teams_left <= 1 then
-			local capture_text = "Player %s captured"
-			if many_teams then
-				capture_text = "Player %s captured the last flag"
-			end
-
-			ctf_modebase.summary.set_winner(string.format(capture_text, minetest.colorize(tcolor, pname)))
-
-			local win_text = HumanReadable(pteam) .. " Team Wins!"
-
-			minetest.chat_send_all(minetest.colorize(pteam, win_text))
-
-			local match_rankings, special_rankings, rank_values, formdef = ctf_modebase.summary.get()
-			formdef.title = win_text
-
-			for _, pn in ipairs(ctf_teams.get_all_team_players()) do
-				ctf_modebase.summary.show_gui(pn, match_rankings, special_rankings, rank_values, formdef)
-			end
-
-			ctf_modebase.start_new_match(5)
-		else
-			for _, lost_team in ipairs(teamnames) do
-				table.remove(team_list, table.indexof(team_list, lost_team))
-
-				for lost_player in pairs(ctf_teams.online_players[lost_team].players) do
-					team_switch_after_capture = true
-						ctf_teams.allocate_player(lost_player)
-					team_switch_after_capture = false
-				end
-			end
-		end
-	end,
-	on_allocplayer = function(player, new_team)
-		player:set_hp(player:get_properties().hp_max)
-
-		if not team_switch_after_capture then
-			ctf_modebase.update_wear.cancel_player_updates(player)
-
-			ctf_modebase.player.remove_bound_items(player)
-			ctf_modebase.player.give_initial_stuff(player)
-		end
-
-		local tcolor = ctf_teams.team[new_team].color
-		player:hud_set_hotbar_image("gui_hotbar.png^[colorize:" .. tcolor .. ":128")
-		player:hud_set_hotbar_selected_image("gui_hotbar_selected.png^[multiply:" .. tcolor)
-
-		player_api.set_texture(player, 1, ctf_cosmetics.get_skin(player))
-
-		recent_rankings.set_team(player, new_team)
-
-		playertag.set(player, playertag.TYPE_ENTITY)
-
-		if player.set_observers then
-			update_playertags()
-		end
-
-		tp_player_near_flag(player)
-	end,
-	on_leaveplayer = function(player)
-		if not ctf_modebase.match_started then
-			ctf_combat_mode.end_combat(player)
+		return image
+	end
+
+	local function tp_player_near_flag(player)
+		local tname = ctf_teams.get(player)
+		if not tname then
 			return
 		end
 
-		local pname = player:get_player_name()
+		local flag_pos = ctf_map.current_map.teams[tname].flag_pos
 
-		-- should be no_hud to avoid a race
-		end_combat_mode(pname, "combatlog")
+		-- Generate random offset
+		local random_off = {
+			x = math.random(-1, 1),
+			y = 0,
+			z = math.random(-1, 1),
+		}
 
-		recent_rankings.on_leaveplayer(pname)
-	end,
-	on_dieplayer = function(player, reason)
-		if not ctf_modebase.match_started then return end
-
-		-- punch is handled in on_punchplayer
-		if reason.type ~= "punch" then
-			end_combat_mode(player:get_player_name(), reason)
+		-- Avoid zero offset
+		if random_off.x == 0 and random_off.z == 0 then
+			random_off.x = 1 -- Shift along X if both are zero
 		end
 
-		if ctf_teams.get(player) then
-			ctf_modebase.prepare_respawn_delay(player)
-		end
-	end,
-	on_respawnplayer = function(player)
-		tp_player_near_flag(player)
-	end,
-	player_is_pro = function(pname)
-		local rank = rankings:get(pname)
-		if is_pro(minetest.get_player_by_name(pname), rank) then
-			return true
-		end
-	end,
-	get_chest_access = function(pname)
-		local rank = rankings:get(pname)
+		local pos = vector.add(flag_pos, random_off)
 
-		local deny_pro = "You need to have more than 1.4 kills per death, "..
-						 "5 captures, and at least 8,000 score to access the pro section."
-		if rank then
-			local captures_needed = math.max(0, 5 - (rank.flag_captures or 0))
-			local score_needed = math.max(math.max(0, 8000 - (rank.score or 0)))
-			local current_kd = math.floor((rank.kills or 0) / (rank.deaths or 1) * 10)
-			current_kd = current_kd / 10
-			deny_pro = deny_pro .. " You still need " .. captures_needed
-					   .. " captures, " .. score_needed ..
-					   " score, and your kills per death is " ..
-					   current_kd .. "."
+		local rotation_y = vector.dir_to_rotation(
+			vector.direction(
+				pos,
+				ctf_map.current_map.teams[tname].look_pos
+					or ctf_map.current_map.flag_center
+			)
+		).y
 
-			if is_pro(minetest.get_player_by_name(pname), rank) then
-				return true, true
-			elseif (rank.score or 0) >= 10 then
-				return true, deny_pro
+		local function apply()
+			player:set_pos(pos)
+			player:set_look_vertical(0)
+			player:set_look_horizontal(rotation_y)
+		end
+
+		apply()
+		minetest.after(0.1, function() -- TODO: remove after respawn bug is fixed
+			if player:is_player() then
+				apply()
+			end
+		end)
+
+		return true
+	end
+
+	local function celebrate_team(teamname)
+		for _, player in ipairs(minetest.get_connected_players()) do
+			local pname = player:get_player_name()
+			local pteam = ctf_teams.get(pname)
+
+			local sound_volume = (
+				tonumber(ctf_settings.get(player, "ctf_modebase:flag_sound_volume"))
+				or 10.0
+			) / 10
+
+			if pteam == teamname then
+				minetest.sound_play("ctf_modebase_trumpet_positive", {
+					to_player = pname,
+					gain = sound_volume,
+					pitch = 1.0,
+				}, true)
+			else
+				minetest.sound_play("ctf_modebase_trumpet_negative", {
+					to_player = pname,
+					gain = sound_volume,
+					pitch = 1.0,
+				}, true)
+			end
+		end
+	end
+
+	local function drop_flag(teamname)
+		for _, player in ipairs(minetest.get_connected_players()) do
+			local pname = player:get_player_name()
+			local pteam = ctf_teams.get(pname)
+
+			if pteam then
+				if pteam == teamname then
+					minetest.sound_play("ctf_modebase_drop_flag_negative", {
+						to_player = pname,
+						gain = 0.2,
+						pitch = 1.0,
+					}, true)
+				else
+					minetest.sound_play("ctf_modebase_drop_flag_positive", {
+						to_player = pname,
+						gain = 0.2,
+						pitch = 1.0,
+					}, true)
+				end
+			end
+		end
+	end
+
+	local function end_combat_mode(player, reason, killer, weapon_image)
+		local comment = nil
+
+		if reason == "combatlog" then
+			killer, weapon_image = ctf_combat_mode.get_last_hitter(player)
+			if killer then
+				comment = " (Combat Log)"
+				recent_rankings.add(player, { deaths = 1 }, true)
+			end
+		else
+			if reason ~= "punch" or killer == player then
+				if ctf_teams.get(player) then
+					if reason == "punch" then
+						ctf_kill_list.add(player, player, weapon_image)
+					else
+						ctf_kill_list.add("", player, get_suicide_image(reason))
+					end
+				end
+
+				killer, weapon_image = ctf_combat_mode.get_last_hitter(player)
+				comment = " (Suicide)"
+			end
+			recent_rankings.add(player, { deaths = 1 }, true)
+		end
+
+		if killer then
+			local killscore = calculate_killscore(player)
+
+			local rewards = { kills = 1, score = killscore }
+			local bounty = ctf_modebase.bounties.claim(player, killer)
+
+			if bounty then
+				for name, amount in pairs(bounty) do
+					rewards[name] = (rewards[name] or 0) + amount
+				end
+			end
+
+			recent_rankings.add(killer, rewards)
+
+			if ctf_teams.get(killer) then
+				ctf_kill_list.add(killer, player, weapon_image, comment)
+			end
+
+			-- share kill score with other hitters
+			local hitters = ctf_combat_mode.get_other_hitters(player, killer)
+			for _, pname in ipairs(hitters) do
+				recent_rankings.add(
+					pname,
+					{ kill_assists = 1, score = math.ceil(killscore / #hitters) }
+				)
+			end
+
+			-- share kill score with healers
+			local healers = ctf_combat_mode.get_healers(killer)
+			for _, pname in ipairs(healers) do
+				recent_rankings.add(pname, { score = math.ceil(killscore / #healers) })
+			end
+
+			if ctf_combat_mode.is_only_hitter(killer, player) then
+				ctf_combat_mode.set_kill_time(killer, 5)
 			end
 		end
 
+		ctf_combat_mode.end_combat(player)
+	end
 
-		return "You need at least 10 score to access this chest", deny_pro
-	end,
-	can_punchplayer = can_punchplayer,
-	on_punchplayer = function(player, hitter, damage, _, tool_capabilities)
-		if not hitter:is_player() or player:get_hp() <= 0 then return false end
-
-		local allowed, message = can_punchplayer(player, hitter)
-
-		if not allowed then
-			return false, message
-		end
-
-		local weapon_image = get_weapon_image(hitter, tool_capabilities)
-
-		if player:get_hp() <= damage then
-			end_combat_mode(player:get_player_name(), "punch", hitter:get_player_name(), weapon_image)
-
-			-- Turn player's camera to face the killer
-			local dir = vector.direction(player:get_pos(), hitter:get_pos())
-			player:set_look_horizontal(minetest.dir_to_yaw(dir))
-		elseif player:get_player_name() ~= hitter:get_player_name() then
-			ctf_combat_mode.add_hitter(player, hitter, weapon_image, 15)
-		end
-
-		return damage
-	end,
-	on_healplayer = function(player, patient, amount)
+	local function can_punchplayer(player, hitter)
 		if not ctf_modebase.match_started then
-			return "The match hasn't started yet!"
+			return false, "The match hasn't started yet!"
 		end
 
-		local score = nil
+		local pname, hname = player:get_player_name(), hitter:get_player_name()
+		local pteam, hteam = ctf_teams.get(player), ctf_teams.get(hitter)
 
-		if ctf_combat_mode.in_combat(patient) then
-			score = 1
+		if not ctf_modebase.remove_respawn_immunity(hitter) then
+			return false, "You can't attack while immune"
 		end
 
-		ctf_combat_mode.add_healer(patient, player, 60)
-		recent_rankings.add(player, {hp_healed = amount, score = score}, true)
-	end,
-	initial_stuff_item_levels = {
-		pick = function(item)
-			local match = item:get_name():match("default:pick_(%a+)")
+		if not pteam then
+			return false, pname .. " is not in a team!"
+		end
 
-			if match then
-				return table.indexof(item_levels, match)
-			end
-		end,
-		axe = function(item)
-			local match = item:get_name():match("default:axe_(%a+)")
+		if not hteam then
+			return false, "You are not in a team!"
+		end
 
-			if match then
-				return table.indexof(item_levels, match)
-			end
-		end,
-		shovel = function(item)
-			local match = item:get_name():match("default:shovel_(%a+)")
+		if pteam == hteam and pname ~= hname then
+			return false, pname .. " is on your team!"
+		end
 
-			if match then
-				return table.indexof(item_levels, match)
-			end
-		end,
-		sword = function(item)
-			local mod, match = item:get_name():match("([^:]+):sword_(%a+)")
+		return true
+	end
 
-			if mod and (mod == "default" or mod == "ctf_melee") and match then
-				return table.indexof(item_levels, match)
-			end
-		end,
+	local item_levels = {
+		"wood",
+		"stone",
+		"bronze",
+		"steel",
+		"mese",
+		"diamond",
 	}
-}
 
+	local delete_queue = {}
+	local team_switch_after_capture = false
+	local streak_bonus_received = {}
+
+	return {
+		on_new_match = function()
+			team_list = {}
+			for tname in pairs(ctf_map.current_map.teams) do
+				table.insert(team_list, tname)
+			end
+			teams_left = #team_list
+			many_teams = #team_list > 2
+
+			-- Detach all players
+			for _, player in ipairs(core.get_connected_players()) do
+				if player:get_attach() then
+					player:set_detach()
+					core.log("action", player:get_player_name() .. " detached")
+				end
+			end
+
+			if #delete_queue > 0 and delete_queue._map ~= ctf_map.current_map.dirname then
+				local p1, p2 = unpack(delete_queue)
+
+				local ignore_objects = {
+					"hpbar:entity",
+					"wield3d:entity",
+					"playertag:tag",
+					"server_cosmetics:hat",
+				}
+
+				for _, obj in pairs(minetest.get_objects_in_area(p1, p2)) do
+					if not obj:is_player() then
+						local luaent = obj:get_luaentity()
+
+						if
+							luaent
+							and table.indexof(ignore_objects, luaent.name) == -1
+						then
+							obj:remove()
+						end
+					end
+				end
+
+				minetest.delete_area(p1, p2)
+
+				delete_queue = {}
+			end
+
+			-- Place treasures
+			local tr = ctf_modebase:get_current_mode().treasures or {}
+
+			local treasurefy_func
+			local no_treasures = true
+			-- If the treasures list is empty, chests will not be placed
+			if next(tr) then
+				local map_treasures = table.copy(tr)
+
+				for k, v in
+					pairs(
+						ctf_map.treasure.treasure_from_string(
+							ctf_map.current_map.treasures
+						)
+					)
+				do
+					map_treasures[k] = v
+				end
+				treasurefy_func = function(inv)
+					ctf_map.treasure.treasurefy_node(inv, map_treasures)
+				end
+				no_treasures = false
+			end
+
+			ctf_map.prepare_map_nodes(
+				ctf_map.current_map,
+				treasurefy_func,
+				no_treasures,
+				ctf_modebase:get_current_mode().team_chest_items or {},
+				ctf_modebase:get_current_mode().blacklisted_nodes or {}
+			)
+
+			if loading_screen_time then
+				local total_time = (minetest.get_us_time() - loading_screen_time) / 1e6
+
+				minetest.after(
+					math.abs(LOADING_SCREEN_TARGET_TIME - total_time),
+					function()
+						hud:clear_all()
+						set_playertags_state(PLAYERTAGS_ON)
+
+						for _, player in ipairs(minetest.get_connected_players()) do
+							minetest.close_formspec(
+								player:get_player_name(),
+								"ctf_modebase:summary"
+							)
+						end
+					end
+				)
+			end
+		end,
+		on_match_end = function()
+			recent_rankings.on_match_end()
+
+			if ctf_map.current_map then
+				-- Queue deletion for after the players have left
+				delete_queue = {
+					ctf_map.current_map.pos1,
+					ctf_map.current_map.pos2,
+					_map = ctf_map.current_map.dirname,
+				}
+			end
+			streak_bonus_received = {}
+		end,
+		team_allocator = function(player)
+			player = PlayerName(player)
+
+			local team_scores = recent_rankings.teams()
+
+			local best_kd = nil
+			local worst_kd = nil
+			local best_players = nil
+			local worst_players = nil
+			local total_players = 0
+
+			for _, team in ipairs(team_list) do
+				local players_count = ctf_teams.online_players[team].count
+				local players = ctf_teams.online_players[team].players
+
+				local bk = 0
+				local bd = 1
+
+				for name in pairs(players) do
+					local rank = rankings:get(name)
+
+					if rank then
+						if bk <= (rank.kills or 0) then
+							bk = rank.kills or 0
+							bd = rank.deaths or 0
+						end
+					end
+				end
+
+				total_players = total_players + players_count
+
+				local kd = bk / bd
+				local match_kd = 0
+				local tk = 0
+				if team_scores[team] then
+					if (team_scores[team].score or 0) >= 50 then
+						tk = team_scores[team].kills or 0
+
+						kd = math.max(
+							kd,
+							(team_scores[team].kills or bk)
+								/ (team_scores[team].deaths or bd)
+						)
+					end
+
+					match_kd = (team_scores[team].kills or 0)
+						/ (team_scores[team].deaths or 1)
+				end
+
+				if not best_kd or match_kd > best_kd.a then
+					best_kd = { s = kd, a = match_kd, t = team, kills = tk }
+				end
+
+				if not worst_kd or match_kd < worst_kd.a then
+					worst_kd = { s = kd, a = match_kd, t = team, kills = tk }
+				end
+
+				if not best_players or players_count > best_players.s then
+					best_players = { s = players_count, t = team }
+				end
+
+				if not worst_players or players_count < worst_players.s then
+					worst_players = { s = players_count, t = team }
+				end
+			end
+
+			if worst_players.s == 0 then
+				return worst_players.t
+			end
+
+			local kd_diff = best_kd.s - worst_kd.s
+			local actual_kd_diff = best_kd.a - worst_kd.a
+			local players_diff = best_players.s - worst_players.s
+
+			local rem_team = ctf_teams.get(player)
+			local player_rankings = recent_rankings.get(player) --[pteam.."_score"]
+
+			if ctf_core.testing.testing then
+				if
+					not rem_team
+					or math.max(
+							player_rankings[rem_team .. "_kills"] or 0,
+							player_rankings[rem_team .. "_deaths"] or 0
+						)
+						<= 6
+				then
+					player_rankings = rankings:get(player) or {}
+				else
+					player_rankings.kills = player_rankings[rem_team .. "_kills"] or 0
+					player_rankings.deaths = player_rankings[rem_team .. "_deaths"] or 1
+				end
+			else
+				player_rankings = {}
+			end
+
+			local one_third = math.ceil(0.34 * total_players)
+			-- local one_fifth     = math.ceil(0.2 * total_players)
+
+			-- Allocate player to remembered team unless teams are imbalanced
+			if
+				rem_team
+				and not ctf_modebase.flag_captured[rem_team]
+				and (worst_kd.kills <= total_players or actual_kd_diff <= 0.8)
+				and players_diff <= one_third
+			then
+				return rem_team
+			end
+
+			local pkd = (player_rankings.kills or 0) / (player_rankings.deaths or 1)
+			local success, result = pcall(
+				ctf_core.testing.test,
+				pkd,
+				kd_diff,
+				actual_kd_diff,
+				players_diff,
+				best_kd,
+				worst_kd,
+				total_players,
+				worst_players,
+				best_players
+			)
+
+			if not success then
+				minetest.log("error", result)
+				result = false
+			end
+
+			-- [1]
+			-- Allocate player to the worst team if it's losing by more than 0.4KD, as long as the amount of-
+			-- players on the winning team isn't outnumbered by more than 1/5 the total players playing
+			-- TODO: extra logic
+
+			-- [2]
+			-- Otherwise allocates the player to the team with the least amount of players,
+			-- or the worst team if all teams have an equal amount of players
+			if players_diff == 0 or result then
+				return worst_kd.t
+			else
+				return worst_players.t
+			end
+		end,
+		can_take_flag = function(player, teamname)
+			if not ctf_modebase.match_started then
+				tp_player_near_flag(player)
+
+				return "You can't take the enemy flag during build time!"
+			end
+		end,
+		--- How much does an item values in score, when you put
+		--- it in teamchest? Currently, it is used when someone dies
+		--- and a teammate puts it back in teamchest. Also it is possible
+		--- for modes to override these values.
+		---
+		--- in the chest. --Farooq
+		--- @param itemname string
+		--- @param teamchest_pos Vec3
+		--- @return number
+		get_item_value = function(itemname, teamchest_pos)
+			-- teamchest_pos is passed
+			-- here for future use. For instanace if we wanted to calculate value
+			-- of an item depending on how many of the same item already exists in
+			local value = default_item_value[itemname]
+			if value == nil then
+				return 0
+			else
+				return value
+			end
+		end,
+		on_flag_take = function(player, teamname)
+			local pname = player:get_player_name()
+			local pteam = ctf_teams.get(player)
+			local tcolor = ctf_teams.team[pteam].color
+
+			ctf_modebase.remove_immunity(player)
+			playertag.set(player, playertag.TYPE_BUILTIN, tcolor)
+
+			local text = " has taken the flag"
+			local flag_or_flags = " flag!"
+			local teamnames_readable = HumanReadable(teamname)
+			if many_teams then
+				text = " has taken " .. teamnames_readable .. "'s flag"
+				flag_or_flags = " flags!"
+			end
+
+			flag_event_notify(
+				pname,
+				pteam,
+				teamname,
+				{ text = "You have taken the " .. teamnames_readable .. flag_or_flags },
+				{
+					text = "Your teammate "
+						.. pname
+						.. " has taken the "
+						.. teamnames_readable
+						.. flag_or_flags,
+				},
+				{ text = pname .. " has taken your flag!", color = "warning" },
+				{ text = pname .. text, color = "light" }
+			)
+
+			minetest.chat_send_all(
+				minetest.colorize(tcolor, pname)
+					.. minetest.colorize(FLAG_MESSAGE_COLOR, text)
+			)
+			ctf_modebase.announce(
+				string.format("Player %s (team %s)%s", pname, pteam, text)
+			)
+
+			celebrate_team(ctf_teams.get(pname))
+
+			recent_rankings.add(pname, { score = 30, flag_attempts = 1 })
+
+			ctf_modebase.flag_huds.track_capturer(pname, FLAG_CAPTURE_TIMER)
+		end,
+		on_flag_drop = function(player, teamnames, pteam)
+			local pname = player:get_player_name()
+			local tcolor = pteam and ctf_teams.team[pteam].color or "#FFF"
+
+			local text = " has dropped the flag"
+			local teamnames_notify = "Your teammate " .. pname .. text
+			if many_teams then
+				text = " has dropped the flag of team(s) " .. HumanReadable(teamnames)
+				teamnames_notify = "Your teammate " .. pname .. text
+			end
+
+			flag_event_notify(
+				pname,
+				pteam,
+				teamnames,
+				nil,
+				{ text = teamnames_notify, color = "light" },
+				{ text = pname .. " has dropped your flag!", color = "success" },
+				{ text = pname .. text, color = "light" }
+			)
+
+			minetest.chat_send_all(
+				minetest.colorize(tcolor, pname)
+					.. minetest.colorize(FLAG_MESSAGE_COLOR, text)
+			)
+			ctf_modebase.announce(
+				string.format("Player %s (team %s)%s", pname, pteam, text)
+			)
+
+			ctf_modebase.flag_huds.untrack_capturer(pname)
+
+			playertag.set(player, playertag.TYPE_ENTITY)
+
+			if player.set_observers then
+				update_playertags()
+			end
+
+			drop_flag(pteam)
+		end,
+		on_flag_capture = function(player, teamnames)
+			local pname = player:get_player_name()
+			local pteam = ctf_teams.get(pname)
+			local tcolor = ctf_teams.team[pteam].color
+
+			playertag.set(player, playertag.TYPE_ENTITY)
+
+			if player.set_observers then
+				update_playertags()
+			end
+
+			celebrate_team(pteam)
+
+			ctf_modebase.flag_huds.untrack_capturer(pname)
+
+			local team_scores = recent_rankings.teams()
+			local capture_reward = 0
+			for _, lost_team in ipairs(teamnames) do
+				local score = ((team_scores[lost_team] or {}).score or 0) / 4
+				score = math.max(10, math.min(900, score))
+				capture_reward = capture_reward + score
+			end
+
+			local text = string.format(
+				" has captured the flag in "
+					.. ctf_map.get_duration()
+					.. " and got %d points",
+				capture_reward
+			)
+			local teamnames_readable = HumanReadable(teamnames)
+			local flag_or_flags = " flag!"
+			if many_teams then
+				text = string.format(
+					" has captured the flag of team(s) %s in "
+						.. ctf_map.get_duration()
+						.. " and got %d points",
+					teamnames_readable,
+					capture_reward
+				)
+				flag_or_flags = " flags!"
+			end
+
+			flag_event_notify(pname, pteam, teamnames, {
+				text = "You have captured: " .. teamnames_readable .. flag_or_flags,
+				color = "success",
+			}, {
+				text = "Your teammate "
+					.. pname
+					.. " has captured: "
+					.. teamnames_readable
+					.. flag_or_flags,
+				color = "success",
+			}, { text = pname .. " has captured your flag!", color = "warning" }, {
+				text = pname .. " has captured: " .. teamnames_readable .. flag_or_flags,
+				color = "light",
+			})
+
+			minetest.chat_send_all(
+				minetest.colorize(tcolor, pname)
+					.. minetest.colorize(FLAG_MESSAGE_COLOR, text)
+			)
+
+			ctf_modebase.announce(
+				string.format("Player %s (team %s)%s", pname, pteam, text)
+			)
+
+			local team_score = team_scores[pteam].score
+			for teammate in pairs(ctf_teams.online_players[pteam].players) do
+				if teammate ~= pname then
+					local teammate_value = (
+						recent_rankings.get(teammate)[pteam .. "_score"] or 0
+					) / (team_score or 1)
+					local victory_bonus = math.max(
+						5,
+						math.min(capture_reward / 2, capture_reward * teammate_value)
+					)
+					recent_rankings.add(teammate, { score = victory_bonus }, true)
+				end
+			end
+
+			recent_rankings.add(
+				pname,
+				{ score = capture_reward, flag_captures = #teamnames }
+			)
+
+			local streak_idx = ctf_modebase.player_on_flag_attempt_streak[pname]
+			if streak_idx then
+				local streak_bonus = 0
+				if streak_bonus_received[pname] then
+					streak_bonus = math.floor(
+						math.abs(streak_bonus_received[pname] - streak_idx * 20)
+					)
+				else
+					streak_bonus = math.floor(streak_idx * 20)
+				end
+				streak_bonus_received[pname] = streak_bonus
+
+				hud_events.new(pname, {
+					text = "Streak Bonus +" .. streak_bonus,
+					color = "info",
+					quick = true,
+				})
+
+				recent_rankings.add(pname, { score = streak_bonus }, true)
+			end
+
+			teams_left = teams_left - #teamnames
+
+			if teams_left <= 1 then
+				local capture_text = "Player %s captured"
+				if many_teams then
+					capture_text = "Player %s captured the last flag"
+				end
+
+				ctf_modebase.summary.set_winner(
+					string.format(capture_text, minetest.colorize(tcolor, pname))
+				)
+
+				local win_text = HumanReadable(pteam) .. " Team Wins!"
+
+				minetest.chat_send_all(minetest.colorize(pteam, win_text))
+
+				local match_rankings, special_rankings, rank_values, formdef =
+					ctf_modebase.summary.get()
+				formdef.title = win_text
+
+				for _, pn in ipairs(ctf_teams.get_all_team_players()) do
+					ctf_modebase.summary.show_gui(
+						pn,
+						match_rankings,
+						special_rankings,
+						rank_values,
+						formdef
+					)
+				end
+
+				ctf_modebase.start_new_match(5)
+			else
+				for _, lost_team in ipairs(teamnames) do
+					table.remove(team_list, table.indexof(team_list, lost_team))
+
+					for lost_player in pairs(ctf_teams.online_players[lost_team].players) do
+						team_switch_after_capture = true
+						ctf_teams.allocate_player(lost_player)
+						team_switch_after_capture = false
+					end
+				end
+			end
+		end,
+		on_allocplayer = function(player, new_team)
+			player:set_hp(player:get_properties().hp_max)
+
+			if not team_switch_after_capture then
+				ctf_modebase.update_wear.cancel_player_updates(player)
+
+				ctf_modebase.player.remove_bound_items(player)
+				ctf_modebase.player.give_initial_stuff(player)
+			end
+
+			local tcolor = ctf_teams.team[new_team].color
+			player:hud_set_hotbar_image("gui_hotbar.png^[colorize:" .. tcolor .. ":128")
+			player:hud_set_hotbar_selected_image(
+				"gui_hotbar_selected.png^[multiply:" .. tcolor
+			)
+
+			player_api.set_texture(player, 1, ctf_cosmetics.get_skin(player))
+
+			recent_rankings.set_team(player, new_team)
+
+			playertag.set(player, playertag.TYPE_ENTITY)
+
+			if player.set_observers then
+				update_playertags()
+			end
+
+			tp_player_near_flag(player)
+		end,
+		on_leaveplayer = function(player)
+			if not ctf_modebase.match_started then
+				ctf_combat_mode.end_combat(player)
+				return
+			end
+
+			local pname = player:get_player_name()
+
+			-- should be no_hud to avoid a race
+			end_combat_mode(pname, "combatlog")
+
+			recent_rankings.on_leaveplayer(pname)
+		end,
+		on_dieplayer = function(player, reason)
+			if not ctf_modebase.match_started then
+				return
+			end
+
+			-- punch is handled in on_punchplayer
+			if reason.type ~= "punch" then
+				end_combat_mode(player:get_player_name(), reason)
+			end
+
+			if ctf_teams.get(player) then
+				ctf_modebase.prepare_respawn_delay(player)
+			end
+		end,
+		on_respawnplayer = function(player)
+			tp_player_near_flag(player)
+		end,
+		player_is_pro = function(pname)
+			local rank = rankings:get(pname)
+			if is_pro(minetest.get_player_by_name(pname), rank) then
+				return true
+			end
+		end,
+		get_chest_access = function(pname)
+			local rank = rankings:get(pname)
+
+			local deny_pro = "You need to have more than 1.4 kills per death, "
+				.. "5 captures, and at least 8,000 score to access the pro section."
+			if rank then
+				local captures_needed = math.max(0, 5 - (rank.flag_captures or 0))
+				local score_needed = math.max(math.max(0, 8000 - (rank.score or 0)))
+				local current_kd = math.floor((rank.kills or 0) / (rank.deaths or 1) * 10)
+				current_kd = current_kd / 10
+				deny_pro = deny_pro
+					.. " You still need "
+					.. captures_needed
+					.. " captures, "
+					.. score_needed
+					.. " score, and your kills per death is "
+					.. current_kd
+					.. "."
+
+				if is_pro(minetest.get_player_by_name(pname), rank) then
+					return true, true
+				elseif (rank.score or 0) >= 10 then
+					return true, deny_pro
+				end
+			end
+
+			return "You need at least 10 score to access this chest", deny_pro
+		end,
+		can_punchplayer = can_punchplayer,
+		on_punchplayer = function(player, hitter, damage, _, tool_capabilities)
+			if not hitter:is_player() or player:get_hp() <= 0 then
+				return false
+			end
+
+			local allowed, message = can_punchplayer(player, hitter)
+
+			if not allowed then
+				return false, message
+			end
+
+			local weapon_image = get_weapon_image(hitter, tool_capabilities)
+
+			if player:get_hp() <= damage then
+				end_combat_mode(
+					player:get_player_name(),
+					"punch",
+					hitter:get_player_name(),
+					weapon_image
+				)
+
+				-- Turn player's camera to face the killer
+				local dir = vector.direction(player:get_pos(), hitter:get_pos())
+				player:set_look_horizontal(minetest.dir_to_yaw(dir))
+			elseif player:get_player_name() ~= hitter:get_player_name() then
+				ctf_combat_mode.add_hitter(player, hitter, weapon_image, 15)
+			end
+
+			return damage
+		end,
+		on_healplayer = function(player, patient, amount)
+			if not ctf_modebase.match_started then
+				return "The match hasn't started yet!"
+			end
+
+			local score = nil
+
+			if ctf_combat_mode.in_combat(patient) then
+				score = 1
+			end
+
+			ctf_combat_mode.add_healer(patient, player, 60)
+			recent_rankings.add(player, { hp_healed = amount, score = score }, true)
+		end,
+		initial_stuff_item_levels = {
+			pick = function(item)
+				local match = item:get_name():match("default:pick_(%a+)")
+
+				if match then
+					return table.indexof(item_levels, match)
+				end
+			end,
+			axe = function(item)
+				local match = item:get_name():match("default:axe_(%a+)")
+
+				if match then
+					return table.indexof(item_levels, match)
+				end
+			end,
+			shovel = function(item)
+				local match = item:get_name():match("default:shovel_(%a+)")
+
+				if match then
+					return table.indexof(item_levels, match)
+				end
+			end,
+			sword = function(item)
+				local mod, match = item:get_name():match("([^:]+):sword_(%a+)")
+
+				if mod and (mod == "default" or mod == "ctf_melee") and match then
+					return table.indexof(item_levels, match)
+				end
+			end,
+		},
+	}
 end

--- a/mods/ctf/ctf_modes/ctf_mode_chaos/init.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_chaos/init.lua
@@ -28,20 +28,31 @@ ctf_modebase.register_mode("chaos", {
 		"ctf_map:spike",
 		"ctf_map:reinforced_cobble 2",
 	},
-	physics = {sneak_glitch = true, new_move = true},
+	physics = { sneak_glitch = true, new_move = true },
 
 	team_chest_items = {
-		"default:cobble 80", "default:wood 80", "ctf_map:damage_cobble 20", "ctf_map:reinforced_cobble 20",
-		"default:torch 30", "ctf_teams:door_steel 2", "default:obsidian 35", "bucket:bucket_water 1",
-		"rocket_launcher:launcher", "rocket_launcher:rocket 5", "heal_block:heal",
+		"default:cobble 80",
+		"default:wood 80",
+		"ctf_map:damage_cobble 20",
+		"ctf_map:reinforced_cobble 20",
+		"default:torch 30",
+		"ctf_teams:door_steel 2",
+		"default:obsidian 35",
+		"bucket:bucket_water 1",
+		"rocket_launcher:launcher",
+		"rocket_launcher:rocket 5",
+		"heal_block:heal",
 	},
 	rankings = rankings,
 	recent_rankings = recent_rankings,
 	summary_ranks = {
 		_sort = "score",
 		"score",
-		"flag_captures", "flag_attempts",
-		"kills", "kill_assists", "bounty_kills",
+		"flag_captures",
+		"flag_attempts",
+		"kills",
+		"kill_assists",
+		"bounty_kills",
 		"deaths",
 	},
 	build_timer = 25,
@@ -57,13 +68,15 @@ ctf_modebase.register_mode("chaos", {
 			"ctf_mode_chaos:knockback_grenade_tool",
 			"default:pick_steel",
 			"default:axe_steel",
-			"default:wood 60"
+			"default:wood 60",
 		}
 	end,
 	initial_stuff_item_levels = features.initial_stuff_item_levels,
 	on_mode_start = function()
-		ctf_modebase.bounties.bounty_reward_func = ctf_modebase.bounty_algo.kd.bounty_reward_func
-		ctf_modebase.bounties.get_next_bounty = ctf_modebase.bounty_algo.kd.get_next_bounty
+		ctf_modebase.bounties.bounty_reward_func =
+			ctf_modebase.bounty_algo.kd.bounty_reward_func
+		ctf_modebase.bounties.get_next_bounty =
+			ctf_modebase.bounty_algo.kd.get_next_bounty
 
 		random_gifts.set_items(rg_treasures)
 		random_gifts.run_spawn_timer()
@@ -74,6 +87,9 @@ ctf_modebase.register_mode("chaos", {
 
 		random_gifts.stop_spawn_timer()
 		random_gifts.set_items({})
+	end,
+	get_item_value = function(itemname, teamchest_pos)
+		return 0
 	end,
 	on_new_match = features.on_new_match,
 	on_match_end = features.on_match_end,
@@ -91,10 +107,25 @@ ctf_modebase.register_mode("chaos", {
 	player_is_pro = features.player_is_pro,
 	can_punchplayer = features.can_punchplayer,
 	on_punchplayer = function(player, hitter, damage, unneeded, tool_capabilities, ...)
-		return features.on_punchplayer(player, hitter, damage, unneeded, tool_capabilities, ...)
+		return features.on_punchplayer(
+			player,
+			hitter,
+			damage,
+			unneeded,
+			tool_capabilities,
+			...
+		)
 	end,
 	on_healplayer = features.on_healplayer,
-	calculate_knockback = function(player, hitter, time_from_last_punch, tool_capabilities, dir, distance, damage)
+	calculate_knockback = function(
+		player,
+		hitter,
+		time_from_last_punch,
+		tool_capabilities,
+		dir,
+		distance,
+		damage
+	)
 		if features.can_punchplayer(player, hitter) then
 			return 4 * (tool_capabilities.damage_groups.knockback or 1)
 		else
@@ -105,9 +136,9 @@ ctf_modebase.register_mode("chaos", {
 
 minetest.register_chatcommand("wannachaos", {
 	description = "Allow chaos mode once",
-	privs = {dev = true},
+	privs = { dev = true },
 	func = function()
 		allow_once = true
 		return true, "Chaos mode enabled for one-time"
-	end
+	end,
 })

--- a/mods/ctf/ctf_modes/ctf_mode_classes/init.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classes/init.lua
@@ -2,10 +2,7 @@ local rankings = ctf_rankings.init()
 local recent_rankings = ctf_modebase.recent_rankings(rankings)
 local features = ctf_modebase.features(rankings, recent_rankings)
 
-local classes = ctf_core.include_files(
-	"paxel.lua",
-	"classes.lua"
-)
+local classes = ctf_core.include_files("paxel.lua", "classes.lua")
 
 local old_bounty_reward_func = ctf_modebase.bounties.bounty_reward_func
 local old_get_next_bounty = ctf_modebase.bounties.get_next_bounty
@@ -17,10 +14,9 @@ local function prioritize_medic_paxel(tooltype)
 		local iname = item:get_name()
 
 		if iname == "ctf_mode_classes:support_paxel" then
-			return
-				features.initial_stuff_item_levels[tooltype](
-					ItemStack(string.format("default:%s_steel", tooltype))
-				) + 0.1,
+			return features.initial_stuff_item_levels[tooltype](
+				ItemStack(string.format("default:%s_steel", tooltype))
+			) + 0.1,
 				true
 		else
 			return features.initial_stuff_item_levels[tooltype](item)
@@ -28,86 +24,175 @@ local function prioritize_medic_paxel(tooltype)
 	end
 end
 
-custom_item_levels.pick   = prioritize_medic_paxel("pick"  )
-custom_item_levels.axe    = prioritize_medic_paxel("axe"   )
+custom_item_levels.pick = prioritize_medic_paxel("pick")
+custom_item_levels.axe = prioritize_medic_paxel("axe")
 custom_item_levels.shovel = prioritize_medic_paxel("shovel")
 
 ctf_modebase.register_mode("classes", {
 	treasures = {
-		["default:ladder_wood" ] = {                max_count = 20, rarity = 0.3, max_stacks = 5},
-		["default:torch"       ] = {                max_count = 20, rarity = 0.3, max_stacks = 5},
+		["default:ladder_wood"] = {
+			max_count = 20,
+			rarity = 0.3,
+			max_stacks = 5,
+		},
+		["default:torch"] = {
+			max_count = 20,
+			rarity = 0.3,
+			max_stacks = 5,
+		},
 
-		["default:cobble"      ] = {min_count = 50, max_count = 99, rarity = 0.3, max_stacks = 2},
-		["default:wood"        ] = {min_count = 50, max_count = 99, rarity = 0.2, max_stacks = 2},
+		["default:cobble"] = {
+			min_count = 50,
+			max_count = 99,
+			rarity = 0.3,
+			max_stacks = 2,
+		},
+		["default:wood"] = {
+			min_count = 50,
+			max_count = 99,
+			rarity = 0.2,
+			max_stacks = 2,
+		},
 
-		["ctf_teams:door_steel"] = {rarity = 0.2, max_stacks = 3},
+		["ctf_teams:door_steel"] = { rarity = 0.2, max_stacks = 3 },
 
-		["default:pick_steel"  ] = {rarity = 0.4, max_stacks = 3},
-		["default:shovel_steel"] = {rarity = 0.4, max_stacks = 2},
-		["default:axe_steel"   ] = {rarity = 0.4, max_stacks = 2},
+		["default:pick_steel"] = { rarity = 0.4, max_stacks = 3 },
+		["default:shovel_steel"] = { rarity = 0.4, max_stacks = 2 },
+		["default:axe_steel"] = { rarity = 0.4, max_stacks = 2 },
 
-		["wind_charges:wind_charge" ] = {min_count = 4, max_count = 8, rarity = 0.4 , max_stacks = 1},
+		["wind_charges:wind_charge"] = {
+			min_count = 4,
+			max_count = 8,
+			rarity = 0.4,
+			max_stacks = 1,
+		},
 
-		["ctf_ranged:pistol_loaded"        ] = {rarity = 0.2 , max_stacks = 2},
-		["ctf_ranged:shotgun_loaded"       ] = {rarity = 0.05                },
-		["ctf_ranged:assault_rifle_loaded"           ] = {rarity = 0.05                },
-		["ctf_ranged:sniper_magnum_loaded" ] = {rarity = 0.05                },
+		["ctf_ranged:pistol_loaded"] = { rarity = 0.2, max_stacks = 2 },
+		["ctf_ranged:shotgun_loaded"] = { rarity = 0.05 },
+		["ctf_ranged:assault_rifle_loaded"] = { rarity = 0.05 },
+		["ctf_ranged:sniper_magnum_loaded"] = { rarity = 0.05 },
 
-		["ctf_map:unwalkable_dirt"  ] = {min_count = 5, max_count = 26, max_stacks = 1, rarity = 0.1},
-		["ctf_map:unwalkable_stone" ] = {min_count = 5, max_count = 26, max_stacks = 1, rarity = 0.1},
-		["ctf_map:unwalkable_cobble"] = {min_count = 5, max_count = 26, max_stacks = 1, rarity = 0.1},
-		["ctf_map:spike"            ] = {min_count = 1, max_count =  5, max_stacks = 2, rarity = 0.2},
-		["ctf_map:damage_cobble"    ] = {min_count = 5, max_count = 20, max_stacks = 2, rarity = 0.2},
-		["ctf_map:reinforced_cobble"] = {min_count = 5, max_count = 25, max_stacks = 2, rarity = 0.2},
+		["ctf_map:unwalkable_dirt"] = {
+			min_count = 5,
+			max_count = 26,
+			max_stacks = 1,
+			rarity = 0.1,
+		},
+		["ctf_map:unwalkable_stone"] = {
+			min_count = 5,
+			max_count = 26,
+			max_stacks = 1,
+			rarity = 0.1,
+		},
+		["ctf_map:unwalkable_cobble"] = {
+			min_count = 5,
+			max_count = 26,
+			max_stacks = 1,
+			rarity = 0.1,
+		},
+		["ctf_map:spike"] = {
+			min_count = 1,
+			max_count = 5,
+			max_stacks = 2,
+			rarity = 0.2,
+		},
+		["ctf_map:damage_cobble"] = {
+			min_count = 5,
+			max_count = 20,
+			max_stacks = 2,
+			rarity = 0.2,
+		},
+		["ctf_map:reinforced_cobble"] = {
+			min_count = 5,
+			max_count = 25,
+			max_stacks = 2,
+			rarity = 0.2,
+		},
 
-		["ctf_ranged:ammo"    ] = {min_count = 3, max_count = 13, rarity = 0.3  , max_stacks = 2},
-		["ctf_healing:medkit" ] = {                               rarity = 0.08 , max_stacks = 2},
+		["ctf_ranged:ammo"] = {
+			min_count = 3,
+			max_count = 13,
+			rarity = 0.3,
+			max_stacks = 2,
+		},
+		["ctf_healing:medkit"] = {
+			rarity = 0.08,
+			max_stacks = 2,
+		},
 
-		["grenades:frag" ] = {rarity = 0.1, max_stacks = 1},
-		["grenades:smoke"] = {rarity = 0.2, max_stacks = 2},
-		["grenades:poison"] = {rarity = 0.1, max_stacks = 2},
+		["grenades:frag"] = { rarity = 0.1, max_stacks = 1 },
+		["grenades:smoke"] = { rarity = 0.2, max_stacks = 2 },
+		["grenades:poison"] = { rarity = 0.1, max_stacks = 2 },
 
-		["default:water_source"] = {rarity = 0.2, max_stacks = 1},
-		["easter_egg:egg"] = {rarity = 0.03, max_stacks = 1},
-		["ctf_landmine:landmine"] = {min_count = 1, max_count =  8, max_stacks = 1, rarity = 0.2},
-		["boats:boat"] = {min_count = 1, max_count =  1, max_stacks = 1, rarity = 0.07},
+		["default:water_source"] = { rarity = 0.2, max_stacks = 1 },
+		["easter_egg:egg"] = { rarity = 0.03, max_stacks = 1 },
+		["ctf_landmine:landmine"] = {
+			min_count = 1,
+			max_count = 8,
+			max_stacks = 1,
+			rarity = 0.2,
+		},
+		["boats:boat"] = { min_count = 1, max_count = 1, max_stacks = 1, rarity = 0.07 },
 	},
 	crafts = {
-		"ctf_ranged:ammo", "default:axe_mese", "default:axe_diamond", "default:shovel_mese", "default:shovel_diamond",
-		"ctf_map:damage_cobble", "ctf_map:spike", "ctf_map:reinforced_cobble 2",
+		"ctf_ranged:ammo",
+		"default:axe_mese",
+		"default:axe_diamond",
+		"default:shovel_mese",
+		"default:shovel_diamond",
+		"ctf_map:damage_cobble",
+		"ctf_map:spike",
+		"ctf_map:reinforced_cobble 2",
 	},
-	physics = {sneak_glitch = true, new_move = false},
-	blacklisted_nodes = {"default:apple"},
+	physics = { sneak_glitch = true, new_move = false },
+	blacklisted_nodes = { "default:apple" },
 	team_chest_items = {
-		"default:cobble 80", "default:wood 80", "ctf_map:damage_cobble 20", "ctf_map:reinforced_cobble 20",
-		"default:torch 30", "ctf_teams:door_steel 2","heal_block:heal",
+		"default:cobble 80",
+		"default:wood 80",
+		"ctf_map:damage_cobble 20",
+		"ctf_map:reinforced_cobble 20",
+		"default:torch 30",
+		"ctf_teams:door_steel 2",
+		"heal_block:heal",
 	},
 	rankings = rankings,
 	recent_rankings = recent_rankings,
 	summary_ranks = {
 		_sort = "score",
 		"score",
-		"flag_captures", "flag_attempts",
-		"kills", "kill_assists", "bounty_kills",
+		"flag_captures",
+		"flag_attempts",
+		"kills",
+		"kill_assists",
+		"bounty_kills",
 		"deaths",
-		"hp_healed"
+		"hp_healed",
 	},
 	build_timer = 90,
 	is_bound_item = function(_, name)
-		if name:match("ctf_mode_classes:") or name:match("ctf_melee:") or name == "ctf_healing:bandage" then
+		if
+			name:match("ctf_mode_classes:")
+			or name:match("ctf_melee:")
+			or name == "ctf_healing:bandage"
+		then
 			return true
 		end
 	end,
 	stuff_provider = function(player)
 		local initial_stuff = table.copy(classes.get(player).items or {})
-		table.insert_all(initial_stuff, {"default:pick_stone", "default:torch 15", "default:stick 5"})
+		table.insert_all(
+			initial_stuff,
+			{ "default:pick_stone", "default:torch 15", "default:stick 5" }
+		)
 		return initial_stuff
 	end,
 	initial_stuff_item_levels = custom_item_levels,
 	is_restricted_item = classes.is_restricted_item,
 	on_mode_start = function()
-		ctf_modebase.bounties.bounty_reward_func = ctf_modebase.bounty_algo.kd.bounty_reward_func
-		ctf_modebase.bounties.get_next_bounty = ctf_modebase.bounty_algo.kd.get_next_bounty
+		ctf_modebase.bounties.bounty_reward_func =
+			ctf_modebase.bounty_algo.kd.bounty_reward_func
+		ctf_modebase.bounties.get_next_bounty =
+			ctf_modebase.bounty_algo.kd.get_next_bounty
 
 		ctf_cosmetics.get_skin = function(player)
 			if not ctf_teams.get(player) then
@@ -127,6 +212,7 @@ ctf_modebase.register_mode("classes", {
 	on_new_match = features.on_new_match,
 	on_match_end = features.on_match_end,
 	team_allocator = features.team_allocator,
+	get_item_value = features.get_item_value,
 	on_allocplayer = function(player, new_team)
 		classes.update(player)
 		features.on_allocplayer(player, new_team)
@@ -146,7 +232,15 @@ ctf_modebase.register_mode("classes", {
 	on_punchplayer = features.on_punchplayer,
 	can_punchplayer = features.can_punchplayer,
 	on_healplayer = features.on_healplayer,
-	calculate_knockback = function(player, hitter, time_from_last_punch, tool_capabilities, dir, distance, damage)
+	calculate_knockback = function(
+		player,
+		hitter,
+		time_from_last_punch,
+		tool_capabilities,
+		dir,
+		distance,
+		damage
+	)
 		if features.can_punchplayer(player, hitter) then
 			return 2 * (tool_capabilities.damage_groups.knockback or 1)
 		else

--- a/mods/ctf/ctf_modes/ctf_mode_classic/init.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_classic/init.lua
@@ -6,59 +6,118 @@ local old_bounty_reward_func = ctf_modebase.bounties.bounty_reward_func
 local old_get_next_bounty = ctf_modebase.bounties.get_next_bounty
 ctf_modebase.register_mode("classic", {
 	treasures = {
-		["default:ladder_wood" ] = {                max_count = 20, rarity = 0.3, max_stacks = 5},
-		["default:torch"       ] = {                max_count = 20, rarity = 0.3, max_stacks = 5},
+		["default:ladder_wood"] = {
+			max_count = 20,
+			rarity = 0.3,
+			max_stacks = 5,
+		},
+		["default:torch"] = {
+			max_count = 20,
+			rarity = 0.3,
+			max_stacks = 5,
+		},
 
-		["default:cobble"      ] = {min_count = 20, max_count = 99, rarity = 0.3, max_stacks = 2},
-		["default:wood"        ] = {min_count = 20, max_count = 99, rarity = 0.2, max_stacks = 2},
+		["default:cobble"] = {
+			min_count = 20,
+			max_count = 99,
+			rarity = 0.3,
+			max_stacks = 2,
+		},
+		["default:wood"] = {
+			min_count = 20,
+			max_count = 99,
+			rarity = 0.2,
+			max_stacks = 2,
+		},
 
-		["ctf_teams:door_steel"] = {rarity = 0.2, max_stacks = 3},
+		["ctf_teams:door_steel"] = { rarity = 0.2, max_stacks = 3 },
 
-		["wind_charges:wind_charge" ] = {min_count = 4, max_count = 8, rarity = 0.4 , max_stacks = 1},
+		["wind_charges:wind_charge"] = {
+			min_count = 4,
+			max_count = 8,
+			rarity = 0.4,
+			max_stacks = 1,
+		},
 
-		["default:pick_steel"  ] = {rarity = 0.4, max_stacks = 3},
-		["default:shovel_steel"] = {rarity = 0.4, max_stacks = 2},
-		["default:axe_steel"   ] = {rarity = 0.4, max_stacks = 2},
+		["default:pick_steel"] = { rarity = 0.4, max_stacks = 3 },
+		["default:shovel_steel"] = { rarity = 0.4, max_stacks = 2 },
+		["default:axe_steel"] = { rarity = 0.4, max_stacks = 2 },
 
-		["ctf_melee:sword_steel"  ] = {rarity = 0.2  , max_stacks = 2},
+		["ctf_melee:sword_steel"] = { rarity = 0.2, max_stacks = 2 },
 
-		["ctf_ranged:pistol_loaded" ] = {rarity = 0.2 , max_stacks = 2},
-		["ctf_ranged:rifle_loaded"  ] = {rarity = 0.2                 },
-		["ctf_ranged:shotgun_loaded"] = {rarity = 0.05                },
-		["ctf_ranged:assault_rifle_loaded"    ] = {rarity = 0.05                },
+		["ctf_ranged:pistol_loaded"] = { rarity = 0.2, max_stacks = 2 },
+		["ctf_ranged:rifle_loaded"] = { rarity = 0.2 },
+		["ctf_ranged:shotgun_loaded"] = { rarity = 0.05 },
+		["ctf_ranged:assault_rifle_loaded"] = { rarity = 0.05 },
 
-		["ctf_ranged:ammo" ] = {min_count = 3, max_count = 10, rarity = 0.3 , max_stacks = 2},
-		["default:apple"   ] = {min_count = 6, max_count = 18, rarity = 0.2 , max_stacks = 2},
+		["ctf_ranged:ammo"] = {
+			min_count = 3,
+			max_count = 10,
+			rarity = 0.3,
+			max_stacks = 2,
+		},
+		["default:apple"] = {
+			min_count = 6,
+			max_count = 18,
+			rarity = 0.2,
+			max_stacks = 2,
+		},
 
-		["grenades:frag" ] = {rarity = 0.1, max_stacks = 1},
-		["grenades:smoke"] = {rarity = 0.2, max_stacks = 2},
+		["grenades:frag"] = { rarity = 0.1, max_stacks = 1 },
+		["grenades:smoke"] = { rarity = 0.2, max_stacks = 2 },
 
-		["default:water_source"] = {rarity = 0.2, max_stacks = 1},
-		["easter_egg:egg"] = {rarity = 0.03, max_stacks = 1},
-		["ctf_landmine:landmine"] = {min_count = 1, max_count =  10, max_stacks = 1, rarity = 0.3},
-		["boats:boat"] = {min_count = 1, max_count =  1, max_stacks = 1, rarity = 0.09},
+		["default:water_source"] = { rarity = 0.2, max_stacks = 1 },
+		["easter_egg:egg"] = { rarity = 0.03, max_stacks = 1 },
+		["ctf_landmine:landmine"] = {
+			min_count = 1,
+			max_count = 10,
+			max_stacks = 1,
+			rarity = 0.3,
+		},
+		["boats:boat"] = { min_count = 1, max_count = 1, max_stacks = 1, rarity = 0.09 },
 	},
-	crafts = {"ctf_ranged:ammo", "ctf_melee:sword_steel", "ctf_melee:sword_mese", "ctf_melee:sword_diamond"},
-	physics = {sneak_glitch = true, new_move = false},
-	team_chest_items = {"default:cobble 99", "default:wood 99", "default:torch 30", "ctf_teams:door_steel 2","heal_block:heal",},
+	crafts = {
+		"ctf_ranged:ammo",
+		"ctf_melee:sword_steel",
+		"ctf_melee:sword_mese",
+		"ctf_melee:sword_diamond",
+	},
+	physics = { sneak_glitch = true, new_move = false },
+	team_chest_items = {
+		"default:cobble 99",
+		"default:wood 99",
+		"default:torch 30",
+		"ctf_teams:door_steel 2",
+		"heal_block:heal",
+	},
 	rankings = rankings,
 	recent_rankings = recent_rankings,
 	summary_ranks = {
 		_sort = "score",
 		"score",
-		"flag_captures", "flag_attempts",
-		"kills", "kill_assists", "bounty_kills",
+		"flag_captures",
+		"flag_attempts",
+		"kills",
+		"kill_assists",
+		"bounty_kills",
 		"deaths",
-		"hp_healed"
+		"hp_healed",
 	},
 
 	stuff_provider = function()
-		return {"default:sword_stone", "default:pick_stone", "default:torch 15", "default:stick 5"}
+		return {
+			"default:sword_stone",
+			"default:pick_stone",
+			"default:torch 15",
+			"default:stick 5",
+		}
 	end,
 	initial_stuff_item_levels = features.initial_stuff_item_levels,
 	on_mode_start = function()
-		ctf_modebase.bounties.bounty_reward_func = ctf_modebase.bounty_algo.kd.bounty_reward_func
-		ctf_modebase.bounties.get_next_bounty = ctf_modebase.bounty_algo.kd.get_next_bounty
+		ctf_modebase.bounties.bounty_reward_func =
+			ctf_modebase.bounty_algo.kd.bounty_reward_func
+		ctf_modebase.bounties.get_next_bounty =
+			ctf_modebase.bounty_algo.kd.get_next_bounty
 	end,
 	on_mode_end = function()
 		ctf_modebase.bounties.bounty_reward_func = old_bounty_reward_func
@@ -78,6 +137,7 @@ ctf_modebase.register_mode("classic", {
 	on_flag_rightclick = function() end,
 	get_chest_access = features.get_chest_access,
 	player_is_pro = features.player_is_pro,
+	get_item_value = features.get_item_value,
 	can_punchplayer = features.can_punchplayer,
 	on_punchplayer = features.on_punchplayer,
 	on_healplayer = features.on_healplayer,

--- a/mods/ctf/ctf_modes/ctf_mode_nade_fight/init.lua
+++ b/mods/ctf/ctf_modes/ctf_mode_nade_fight/init.lua
@@ -2,6 +2,33 @@ local rankings = ctf_rankings.init()
 local recent_rankings = ctf_modebase.recent_rankings(rankings)
 local features = ctf_modebase.features(rankings, recent_rankings)
 
+--- @type { [string]: number }
+local item_value = {
+	["ctf_melee:sword_diamond"] = 12,
+	["ctf_ranged:shotgun_loaded"] = 14,
+	["ctf_melee:sword_mese"] = 16,
+	["ctf_ranged:shotgun"] = 14,
+	["default:axe_diamond"] = 5,
+	["ctf_ranged:assault_rifle_loaded"] = 10,
+	["ctf_melee:sword_steel"] = 5,
+	["default:pick_diamond"] = 5,
+	["ctf_ranged:assault_rifle"] = 10,
+	["ctf_healing:medkit"] = 7,
+	["default:pick_mese"] = 1,
+	["default:axe_mese"] = 1,
+	["grenades:poison"] = 3,
+	["ctf_ranged:rifle_loaded"] = 5,
+	["ctf_ranged:smg_loaded"] = 5,
+	["ctf_ranged:rifle"] = 5,
+	["ctf_ranged:smg"] = 5,
+	["ctf_healing:bandage"] = 6,
+	["default:shovel_diamond"] = 6,
+	["grenades:smoke"] = 2,
+	["ctf_ranged:pistol_loaded"] = 1,
+	["default:shovel_mese"] = 1,
+	["ctf_ranged:pistol"] = 1,
+}
+
 local tool = ctf_core.include_files("tool.lua")
 
 local old_bounty_reward_func = ctf_modebase.bounties.bounty_reward_func
@@ -9,67 +36,139 @@ local old_get_next_bounty = ctf_modebase.bounties.get_next_bounty
 ctf_modebase.register_mode("nade_fight", {
 	hp_regen = 2,
 	treasures = {
-		["default:ladder_wood" ] = {                max_count = 20, rarity = 0.3, max_stacks = 5},
-		["default:torch"       ] = {                max_count = 20, rarity = 0.3, max_stacks = 5},
+		["default:ladder_wood"] = {
+			max_count = 20,
+			rarity = 0.3,
+			max_stacks = 5,
+		},
+		["default:torch"] = {
+			max_count = 20,
+			rarity = 0.3,
+			max_stacks = 5,
+		},
 
-		["default:cobble"      ] = {min_count = 45, max_count = 99, rarity = 0.4, max_stacks = 4},
-		["default:wood"        ] = {min_count = 10, max_count = 60, rarity = 0.4, max_stacks = 4},
+		["default:cobble"] = {
+			min_count = 45,
+			max_count = 99,
+			rarity = 0.4,
+			max_stacks = 4,
+		},
+		["default:wood"] = {
+			min_count = 10,
+			max_count = 60,
+			rarity = 0.4,
+			max_stacks = 4,
+		},
 
-		["ctf_teams:door_steel"] = {rarity = 0.2, max_stacks = 3},
+		["ctf_teams:door_steel"] = { rarity = 0.2, max_stacks = 3 },
 
-		["default:pick_mese"  ] = {rarity = 0.4, max_stacks = 3},
-		["default:shovel_mese"] = {rarity = 0.4, max_stacks = 2},
-		["default:axe_mese"   ] = {rarity = 0.4, max_stacks = 2},
+		["default:pick_mese"] = { rarity = 0.4, max_stacks = 3 },
+		["default:shovel_mese"] = { rarity = 0.4, max_stacks = 2 },
+		["default:axe_mese"] = { rarity = 0.4, max_stacks = 2 },
 
-		["default:pick_diamond"  ] = {rarity = 0.05, max_stacks = 3},
-		["default:shovel_diamond"] = {rarity = 0.05, max_stacks = 2},
-		["default:axe_diamond"   ] = {rarity = 0.05, max_stacks = 2},
+		["default:pick_diamond"] = { rarity = 0.05, max_stacks = 3 },
+		["default:shovel_diamond"] = { rarity = 0.05, max_stacks = 2 },
+		["default:axe_diamond"] = { rarity = 0.05, max_stacks = 2 },
 
-		["ctf_melee:sword_steel" ] = {rarity = 0.4  , max_stacks = 1},
-		["ctf_melee:sword_mese"  ] = {rarity = 0.05 , max_stacks = 1},
+		["ctf_melee:sword_steel"] = { rarity = 0.4, max_stacks = 1 },
+		["ctf_melee:sword_mese"] = { rarity = 0.05, max_stacks = 1 },
 
-		["ctf_ranged:pistol_loaded" ] = {rarity = 0.2 , max_stacks = 2},
-		["ctf_ranged:rifle_loaded"  ] = {rarity = 0.2                 },
-		["ctf_ranged:shotgun_loaded"] = {rarity = 0.05                },
-		["ctf_ranged:assault_rifle_loaded"    ] = {rarity = 0.05                },
+		["ctf_ranged:pistol_loaded"] = { rarity = 0.2, max_stacks = 2 },
+		["ctf_ranged:rifle_loaded"] = { rarity = 0.2 },
+		["ctf_ranged:shotgun_loaded"] = { rarity = 0.05 },
+		["ctf_ranged:assault_rifle_loaded"] = { rarity = 0.05 },
 
-		["ctf_map:unwalkable_dirt"  ] = {min_count = 5, max_count = 26, max_stacks = 1, rarity = 0.1},
-		["ctf_map:unwalkable_stone" ] = {min_count = 5, max_count = 26, max_stacks = 1, rarity = 0.1},
-		["ctf_map:unwalkable_cobble"] = {min_count = 5, max_count = 26, max_stacks = 1, rarity = 0.1},
-		["ctf_map:spike"            ] = {min_count = 1, max_count =  5, max_stacks = 3, rarity = 0.2},
-		["ctf_map:damage_cobble"    ] = {min_count = 5, max_count = 20, max_stacks = 2, rarity = 0.2},
-		["ctf_map:reinforced_cobble"] = {min_count = 5, max_count = 25, max_stacks = 2, rarity = 0.2},
+		["ctf_map:unwalkable_dirt"] = {
+			min_count = 5,
+			max_count = 26,
+			max_stacks = 1,
+			rarity = 0.1,
+		},
+		["ctf_map:unwalkable_stone"] = {
+			min_count = 5,
+			max_count = 26,
+			max_stacks = 1,
+			rarity = 0.1,
+		},
+		["ctf_map:unwalkable_cobble"] = {
+			min_count = 5,
+			max_count = 26,
+			max_stacks = 1,
+			rarity = 0.1,
+		},
+		["ctf_map:spike"] = {
+			min_count = 1,
+			max_count = 5,
+			max_stacks = 3,
+			rarity = 0.2,
+		},
+		["ctf_map:damage_cobble"] = {
+			min_count = 5,
+			max_count = 20,
+			max_stacks = 2,
+			rarity = 0.2,
+		},
+		["ctf_map:reinforced_cobble"] = {
+			min_count = 5,
+			max_count = 25,
+			max_stacks = 2,
+			rarity = 0.2,
+		},
 
-		["ctf_ranged:ammo"     ] = {min_count = 3, max_count = 10, rarity = 0.3  , max_stacks = 2},
-		["ctf_healing:medkit"  ] = {                               rarity = 0.1  , max_stacks = 2},
-		["ctf_healing:bandage" ] = {                               rarity = 0.08 , max_stacks = 2},
+		["ctf_ranged:ammo"] = {
+			min_count = 3,
+			max_count = 10,
+			rarity = 0.3,
+			max_stacks = 2,
+		},
+		["ctf_healing:medkit"] = {
+			rarity = 0.1,
+			max_stacks = 2,
+		},
+		["ctf_healing:bandage"] = {
+			rarity = 0.08,
+			max_stacks = 2,
+		},
 
-		["grenades:smoke"] = {rarity = 0.2, max_stacks = 3},
-		["grenades:poison"] = {rarity = 0.1, max_stacks = 2},
-		["default:water_source"] = {rarity = 0.2, max_stacks = 1},
-		["easter_egg:egg"] = {rarity = 0.03, max_stacks = 1},
-		["ctf_landmine:landmine"] = {min_count = 1, max_count =  2, max_stacks = 1, rarity = 0.1},
+		["grenades:smoke"] = { rarity = 0.2, max_stacks = 3 },
+		["grenades:poison"] = { rarity = 0.1, max_stacks = 2 },
+		["default:water_source"] = { rarity = 0.2, max_stacks = 1 },
+		["easter_egg:egg"] = { rarity = 0.03, max_stacks = 1 },
+		["ctf_landmine:landmine"] = {
+			min_count = 1,
+			max_count = 2,
+			max_stacks = 1,
+			rarity = 0.1,
+		},
 	},
 	crafts = {
 		"ctf_map:damage_cobble",
 		"ctf_map:spike",
 		"ctf_map:reinforced_cobble 2",
 	},
-	physics = {sneak_glitch = true, new_move = false},
-	blacklisted_nodes = {"default:apple"},
+	physics = { sneak_glitch = true, new_move = false },
+	blacklisted_nodes = { "default:apple" },
 	team_chest_items = {
-		"default:cobble 80", "default:wood 80", "ctf_map:damage_cobble 20", "ctf_map:reinforced_cobble 20",
-		"default:torch 30", "ctf_teams:door_steel 2","heal_block:heal",
+		"default:cobble 80",
+		"default:wood 80",
+		"ctf_map:damage_cobble 20",
+		"ctf_map:reinforced_cobble 20",
+		"default:torch 30",
+		"ctf_teams:door_steel 2",
+		"heal_block:heal",
 	},
 	rankings = rankings,
 	recent_rankings = recent_rankings,
 	summary_ranks = {
 		_sort = "score",
 		"score",
-		"flag_captures", "flag_attempts",
-		"kills", "kill_assists", "bounty_kills",
+		"flag_captures",
+		"flag_attempts",
+		"kills",
+		"kill_assists",
+		"bounty_kills",
 		"deaths",
-		"hp_healed"
+		"hp_healed",
 	},
 	build_timer = 60 * 2,
 
@@ -83,13 +182,15 @@ ctf_modebase.register_mode("nade_fight", {
 			tool.get_grenade_tool(player),
 			"default:pick_steel",
 			"default:shovel_steel",
-			"default:axe_steel"
+			"default:axe_steel",
 		}
 	end,
 	initial_stuff_item_levels = features.initial_stuff_item_levels,
 	on_mode_start = function()
-		ctf_modebase.bounties.bounty_reward_func = ctf_modebase.bounty_algo.kd.bounty_reward_func
-		ctf_modebase.bounties.get_next_bounty = ctf_modebase.bounty_algo.kd.get_next_bounty
+		ctf_modebase.bounties.bounty_reward_func =
+			ctf_modebase.bounty_algo.kd.bounty_reward_func
+		ctf_modebase.bounties.get_next_bounty =
+			ctf_modebase.bounty_algo.kd.get_next_bounty
 	end,
 	on_mode_end = function()
 		ctf_modebase.bounties.bounty_reward_func = old_bounty_reward_func
@@ -110,6 +211,14 @@ ctf_modebase.register_mode("nade_fight", {
 	get_chest_access = features.get_chest_access,
 	player_is_pro = features.player_is_pro,
 	can_punchplayer = features.can_punchplayer,
+	get_item_value = function(itemname, teamchest_pos)
+		local value = item_value[itemname]
+		if value == nil then
+			return 0
+		else
+			return value
+		end
+	end,
 	on_punchplayer = function(player, hitter, damage, unneeded, tool_capabilities, ...)
 		if tool.holed[player:get_player_name()] then
 			if tool_capabilities.grenade then
@@ -119,7 +228,14 @@ ctf_modebase.register_mode("nade_fight", {
 			end
 		end
 
-		return features.on_punchplayer(player, hitter, damage, unneeded, tool_capabilities, ...)
+		return features.on_punchplayer(
+			player,
+			hitter,
+			damage,
+			unneeded,
+			tool_capabilities,
+			...
+		)
 	end,
 	on_healplayer = features.on_healplayer,
 	calculate_knockback = function()

--- a/mods/ctf/ctf_teams/team_chest.lua
+++ b/mods/ctf/ctf_teams/team_chest.lua
@@ -5,40 +5,6 @@ local blacklist = {
 	"default:pick_stone",
 }
 
-local item_value = {
-	["ctf_melee:sword_diamond"] = 12,
-	["ctf_ranged:shotgun_loaded"] = 12,
-	["ctf_melee:sword_mese"] = 11,
-	["ctf_ranged:shotgun"] = 10,
-	["ctf_ranged:sniper_magnum_loaded"] = 12,
-	["default:axe_diamond"] = 8,
-	["ctf_ranged:sniper_magnum"] = 10,
-	["ctf_ranged:assault_rifle_loaded"] = 8,
-	["rocket_launcher:launcher"] = 8,
-	["default:sword_steel"] = 7,
-	["ctf_melee:sword_steel"] = 7,
-	["default:pick_diamond"] = 6,
-	["ctf_ranged:assault_rifle"] = 6,
-	["grenades:frag"] = 6,
-	["ctf_healing:medkit"] = 6,
-	["default:pick_mese"] = 5,
-	["default:axe_mese"] = 5,
-	["grenades:poison"] = 5,
-	["ctf_ranged:rifle_loaded"] = 5,
-	["ctf_ranged:smg_loaded"] = 5,
-	["ctf_ranged:rifle"] = 4,
-	["ctf_ranged:smg"] = 4,
-	["ctf_healing:bandage"] = 4,
-	["default:shovel_diamond"] = 4,
-	["grenades:smoke"] = 2,
-	["ctf_ranged:pistol_loaded"] = 2,
-	["default:shovel_steel"] = 2,
-	["default:pick_steel"] = 1,
-	["default:axe_steel"] = 1,
-	["default:shovel_mese"] = 1,
-	["ctf_ranged:pistol"] = 1,
-}
-
 local S = core.get_translator(minetest.get_current_modname())
 
 --- Does the player have access to the chest?
@@ -361,18 +327,19 @@ for _, team in ipairs(ctf_teams.teamlist) do
 				local cur_mode = ctf_modebase:get_current_mode()
 				if pname and cur_mode then
 					local item_name = stack:get_name()
-					local score = item_value[item_name] or 1
+					local score = cur_mode:get_item_value(stack:get_name(), pos)
+					if score > 0 then
+						local item_desc = stack:get_short_description()
+						if item_desc == "" then
+							item_desc = item_name
+						end
 
-					local item_desc = stack:get_short_description()
-					if item_desc == "" then
-						item_desc = item_name
+						cur_mode.recent_rankings.add(pname, { score = score }, true)
+						cmsg.push_message_player(
+							player,
+							string.format("+ %s: %s", score, item_desc)
+						)
 					end
-
-					cur_mode.recent_rankings.add(pname, { score = score }, true)
-					cmsg.push_message_player(
-						player,
-						string.format("+ %s: %s", score, item_desc)
-					)
 				end
 			end
 			meta:set_string("dropped_by", "")


### PR DESCRIPTION
Now the score for returning items to teamchest is specific per mode. And in nade fight, it doesn't make sense to give so much score for mese tools. Therefore, their values are now 1. On the other hand, the value of mese sword has increased 50%.

Also there is now 0 score in chaos mode regardless of the item.