### PR TITLE
Fix Bug: Can open chest with apple

### DIFF
--- a/mods/mtg_custom/ctf_changes/init.lua
+++ b/mods/mtg_custom/ctf_changes/init.lua
@@ -86,7 +86,13 @@ minetest.override_item("default:apple", {
 	end,
 	after_place_node = nil,
 	stack_max = 60,
-	on_place = function()
+	on_place = function(itemstack, placer, pointed_thing)
+		local under = pointed_thing.under
+		local node = minetest.get_node(under)
+		local udef = minetest.registered_nodes[node.name]
+		if udef and udef.on_rightclick and not (placer and placer:is_player() and placer:get_player_control().sneak) then
+				udef.on_rightclick(under, node, placer, itemstack, pointed_thing)
+		end
 		return nil
 	end
 })


### PR DESCRIPTION
Fixes https://github.com/Minetest-JMA-group/jma-capturetheflag/issues/122 

Description:
This pull request fixes the issue where right-clicking a chest (or other nodes with rightclick) while holding an apple, does not trigger the node's rightclick behavior. This change also ensures that apples cannot be placed in line with the current behavior. 

Changes:
Updated on_place function in apple craftitem definition to handle node interaction when using. 