### PR TITLE
the minimum score given for digging a heal block is 20

### DIFF
--- a/mods/other/heal_block/init.lua
+++ b/mods/other/heal_block/init.lua
@@ -90,8 +90,10 @@ minetest.register_node("heal_block:heal", {
 			end
 			local meta = core.get_meta(pos)
 			local healed_points = meta:get_int("healed_points")
-			local break_reward =
-				math.max(HEAL_DIG_REWARD_BASE, healed_points * BREAK_REWARD_PER_HP)
+			local break_reward = math.max(
+				HEAL_DIG_REWARD_BASE,
+				math.ceil(healed_points * BREAK_REWARD_PER_HP)
+			)
 			cur_mode.recent_rankings.add(
 				digger:get_player_name(),
 				{ score = break_reward },

--- a/mods/other/heal_block/init.lua
+++ b/mods/other/heal_block/init.lua
@@ -2,6 +2,7 @@
 -- Copyright (c) 2024 Ivan Shkatov (Maintainer_) ivanskatov672@gmail.com
 
 local BREAK_REWARD_PER_HP = 0.1
+local HEAL_DIG_REWARD_BASE = 20
 
 minetest.register_node("heal_block:heal", {
 	description = "Healing Block\n"
@@ -89,7 +90,8 @@ minetest.register_node("heal_block:heal", {
 			end
 			local meta = core.get_meta(pos)
 			local healed_points = meta:get_int("healed_points")
-			local break_reward = healed_points * BREAK_REWARD_PER_HP
+			local break_reward =
+				math.max(HEAL_DIG_REWARD_BASE, healed_points * BREAK_REWARD_PER_HP)
 			cur_mode.recent_rankings.add(
 				digger:get_player_name(),
 				{ score = break_reward },


### PR DESCRIPTION
After https://github.com/Minetest-JMA-group/jma-capturetheflag/pull/100, now digging heal blocks gives 0 if the heal block didn't heal anyone. But this doesn't make sense. As digging it certainly hurts the enemy team.

This PR gives a minimum score of 20 like before. Also I've used `math.ceil` in the case reward wasn't an integer.