### PR TITLE
Fix Bug: When Player dies or leaves the item (Rocket, Nade) is not stuck on cooldown.

### DIFF
--- a/mods/ctf/ctf_modebase/update_wear.lua
+++ b/mods/ctf/ctf_modebase/update_wear.lua
@@ -79,6 +79,7 @@ function ctf_modebase.update_wear.start_update(
 	end
 
 	wear_timers[pname][item_id] = {
+		d = down,
 		c = cancel_callback,
 		t = core.after(1, function()
 			wear_timers[pname][item_id] = nil
@@ -147,8 +148,8 @@ ctf_api.register_on_match_end(function()
 	item_pos_cache = {} -- Clear the cache on match end
 end)
 
-function ctf_modebase.update_wear.cancel_player_updates(pname, force)
-	pname = PlayerName(pname)
+function ctf_modebase.update_wear.cancel_player_updates(player, force)
+	pname = PlayerName(player)
 
 	if not force and ctf_teams.non_team_players[pname] then
 		return
@@ -160,16 +161,20 @@ function ctf_modebase.update_wear.cancel_player_updates(pname, force)
 				timer.c(item_id)
 			end
 			timer.t:cancel()
+
+			local pinv = player:get_inventory()
+			local pos, stack = ctf_modebase.update_wear.find_item_by_id(pinv, item_id)
+			if timer.d then
+				stack:set_wear(0)
+			else
+				stack:set_wear(65534)
+			end
+			pinv:set_stack("main", pos, stack)
+
+
 		end
 
 		wear_timers[pname] = nil
 	end
 end
 
-core.register_on_dieplayer(function(player)
-	ctf_modebase.update_wear.cancel_player_updates(player)
-end)
-
-core.register_on_leaveplayer(function(player)
-	ctf_modebase.update_wear.cancel_player_updates(player, true)
-end)

--- a/mods/ctf/ctf_pvp/dropondie/init.lua
+++ b/mods/ctf/ctf_pvp/dropondie/init.lua
@@ -37,6 +37,7 @@ function dropondie.drop_all(player)
 
 	ctf_modebase.player.remove_bound_items(player)
 	ctf_modebase.player.remove_initial_stuff(player)
+	ctf_modebase.update_wear.cancel_player_updates(player)
 
 	local pos = player:get_pos()
 	pos.y = math.floor(pos.y + 0.5)


### PR DESCRIPTION
Copy of https://github.com/Minetest-JMA-group/jma-capturetheflag/pull/160 because I accidentally closed it. I’ve also added the call to the function in ‘dropondie’ to make sure everything runs in the correct order. I decided not to create the API callback because there are already other functions being called in 'dropondie' so it’s better handled in a separate PR.